### PR TITLE
fix(test): gate_check_pass_no_warning 오탐 패턴 수정

### DIFF
--- a/tests/unit/commands/make_branches.sh
+++ b/tests/unit/commands/make_branches.sh
@@ -80,7 +80,7 @@ JAVA
         BOJ_AGENT_CMD="echo MOCK_AGENT" \
         bash -c "echo y | '$tmp/src/boj' make 99999 --no-open" 2>&1) || true
 
-  assert_output_not_contains "gate_check_pass_no_warning: Gate Check Warning 없음" "$out" "Gate Check"
+  assert_output_not_contains "gate_check_pass_no_warning: Gate Check Warning 없음" "$out" "Warning: Gate Check"
 
   teardown_tmp "$tmp"
 }


### PR DESCRIPTION
## 원인

`gate_check_pass_no_warning` 테스트가 출력에 `"Gate Check"` 문자열이 없는지 검사했는데, `BOJ_AGENT_CMD="echo MOCK_AGENT"` 실행 시 에이전트 프롬프트 전체(`make-skeleton.md`)가 stdout에 출력됩니다.

`make-skeleton.md` 안에 아래 문장이 포함되어 있어 오탐 발생:
\`\`\`
> **참고**: 생성 완료 후 make.sh가 자동으로 Gate Check를 수행합니다.
\`\`\`

실제 make.sh gate check 경고 메시지:
\`\`\`
Warning: Gate Check — solve()가 단일 String/str 파라미터(raw stdin blob)를 사용합니다.
\`\`\`

## 수정

패턴을 `"Gate Check"` → `"Warning: Gate Check"`로 구체화.
실제 경고만 매칭하고 프롬프트 참조 텍스트는 무시.

## 변경 파일

- `tests/unit/commands/make_branches.sh` — 1줄 수정

## 검증

```
make_branches: 6개 통과, 0개 실패
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a unit test’s match pattern to be more specific, with no production logic changes.
> 
> **Overview**
> Tightens the `gate_check_pass_no_warning` unit test to assert the absence of the specific `Warning: Gate Check` message (instead of any `Gate Check` text), preventing false failures caused by unrelated prompt/template output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0165dab2a86807688c770f66247f6868d3c42b23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->