### PR TITLE
feat(open): migrate boj open from Bash to Python [#66]

### DIFF
--- a/src/boj
+++ b/src/boj
@@ -128,7 +128,22 @@ case "$SUBCOMMAND" in
       exec "$CMD_SCRIPT" "$ROOT" "$PROBLEM_NUM" "${@:3}"
     fi
     ;;
-  commit|open|review|submit)
+  open)
+    # Python 마이그레이션 (#66): src/cli/boj_open.py로 라우팅
+    OPEN_PY="$ROOT/src/cli/boj_open.py"
+    if [[ -f "$OPEN_PY" ]]; then
+      shift  # subcommand 제거
+      PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" exec python3 "$OPEN_PY" "$@"
+    else
+      # fallback: 기존 Bash
+      if [[ ! -x "$CMD_SCRIPT" ]]; then
+        echo "Error: $CMD_SCRIPT 를 찾을 수 없거나 실행할 수 없습니다." >&2
+        exit 1
+      fi
+      exec "$CMD_SCRIPT" "$ROOT" "$PROBLEM_NUM" "${@:3}"
+    fi
+    ;;
+  commit|review|submit)
     if [[ ! -x "$CMD_SCRIPT" ]]; then
       echo "Error: $CMD_SCRIPT 를 찾을 수 없거나 실행할 수 없습니다." >&2
       echo "  (chmod +x $CMD_SCRIPT 로 실행 권한을 추가해보세요)" >&2

--- a/src/cli/boj_open.py
+++ b/src/cli/boj_open.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""boj open CLI 래퍼 — 인수 파싱 + 에디터 실행.
+
+Issue #66 — open.sh Python 마이그레이션.
+
+사용법:
+    python -m src.cli.boj_open <문제번호> [--editor code|cursor|vim]
+    또는 boj 디스패처에서 호출.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.core.exceptions import BojError
+from src.core.open import open_problem
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI 인수를 파싱한다.
+
+    Args:
+        argv: 인수 리스트. None이면 sys.argv[1:] 사용.
+
+    Returns:
+        파싱된 Namespace.
+    """
+    parser = argparse.ArgumentParser(
+        prog="boj open",
+        description="문제 폴더를 에디터로 열기",
+    )
+    parser.add_argument(
+        "problem_id",
+        help="문제 번호 (예: 99999)",
+    )
+    parser.add_argument(
+        "--editor",
+        default=None,
+        help="에디터 override (code|cursor|vim). 미지정 시 config 사용.",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="풀이 루트 디렉터리 override.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """boj open 메인 진입점.
+
+    Args:
+        argv: CLI 인수. None이면 sys.argv[1:].
+
+    Returns:
+        exit code (0=성공, 1=에러).
+    """
+    args = parse_args(argv)
+
+    base_dir = Path(args.root) if args.root else None
+
+    try:
+        open_problem(
+            problem_id=args.problem_id,
+            editor=args.editor,
+            base_dir=base_dir,
+        )
+        return 0
+
+    except BojError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    except KeyboardInterrupt:
+        print("\n중단되었습니다.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/open.py
+++ b/src/core/open.py
@@ -1,0 +1,121 @@
+"""boj open 핵심 로직 — 문제 폴더를 에디터로 열기.
+
+Issue #66 — open.sh Python 마이그레이션.
+"""
+
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from src.core.config import config_get, find_problem_dir
+from src.core.exceptions import BojError
+
+
+# ---------------------------------------------------------------------------
+# find_or_create_problem_dir
+# ---------------------------------------------------------------------------
+
+def find_or_create_problem_dir(
+    problem_id: str,
+    base_dir: Path | None = None,
+) -> Path:
+    """문제 번호로 시작하는 폴더를 찾아 경로를 반환한다.
+
+    Args:
+        problem_id: 문제 번호 (예: "99999").
+        base_dir: 풀이 루트 디렉터리. None이면 config에서 읽음.
+
+    Returns:
+        찾은 문제 폴더 경로.
+
+    Raises:
+        BojError: 문제 폴더를 찾을 수 없을 때 (O1).
+    """
+    if base_dir is None:
+        root_str = config_get("solution_root", "")
+        base_dir = Path(root_str) if root_str else Path.cwd()
+
+    result = find_problem_dir(str(base_dir), problem_id)
+    if result is None:
+        raise BojError(
+            f"'{problem_id}' 문제 폴더가 없습니다. "
+            f"먼저 boj make {problem_id} 를 실행하세요."
+        )
+
+    return Path(result)
+
+
+# ---------------------------------------------------------------------------
+# open_in_editor
+# ---------------------------------------------------------------------------
+
+def open_in_editor(problem_dir: Path, editor_cmd: str | None) -> None:
+    """에디터로 문제 폴더를 연다 (non-blocking).
+
+    Popen으로 실행하여 CLI가 에디터 종료를 기다리지 않는다.
+
+    Args:
+        problem_dir: 문제 폴더 경로.
+        editor_cmd: 에디터 명령어 (예: "code", "cursor", "vim").
+
+    Raises:
+        BojError: 에디터가 설정되지 않았을 때 (O2).
+        BojError: 에디터를 PATH에서 찾을 수 없을 때 (O4).
+    """
+    if not (editor_cmd or "").strip():
+        raise BojError(
+            "에디터가 설정되지 않았습니다. "
+            "--editor 옵션 또는 boj setup에서 에디터를 설정하세요."
+        )
+
+    editor_name = shlex.split(editor_cmd.strip())[0]
+    if shutil.which(editor_name) is None:
+        raise BojError(
+            f"설정된 에디터 '{editor_name}'을(를) "
+            f"찾을 수 없습니다. PATH를 확인하세요."
+        )
+
+    cmd = [*shlex.split(editor_cmd.strip()), str(problem_dir)]
+    subprocess.Popen(cmd, cwd=str(problem_dir))
+
+
+# ---------------------------------------------------------------------------
+# open_problem (메인 함수)
+# ---------------------------------------------------------------------------
+
+def open_problem(
+    problem_id: str,
+    editor: str | None = None,
+    base_dir: Path | None = None,
+) -> Path:
+    """boj open의 핵심 로직.
+
+    Args:
+        problem_id: 문제 번호 (예: "99999").
+        editor: 에디터 override. None이면 config에서 읽음.
+        base_dir: 풀이 루트 디렉터리. None이면 config에서 읽음.
+
+    Returns:
+        열린 문제 폴더 경로.
+
+    Raises:
+        BojError: 문제 폴더 없음 (O1), 에디터 미설정 (O2),
+                  에디터 PATH 없음 (O4).
+    """
+    # 에디터 결정 (O3: --editor flag override)
+    editor_cmd = editor or config_get("editor", "")
+
+    # 문제 폴더 찾기
+    problem_dir = find_or_create_problem_dir(problem_id, base_dir)
+
+    # 에디터로 열기
+    open_in_editor(problem_dir, editor_cmd)
+
+    print(
+        f"문제 폴더를 에디터로 열었습니다: {problem_dir.name}",
+        file=sys.stderr,
+    )
+
+    return problem_dir

--- a/tests/integration/test_open_py.py
+++ b/tests/integration/test_open_py.py
@@ -1,0 +1,95 @@
+"""boj open 통합 테스트 — subprocess로 실행.
+
+Issue #66 — open.sh Python 마이그레이션.
+edge-cases O1-O4 커버리지 (integration 레벨).
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_boj, setup_problem_dir
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Happy Path
+# ---------------------------------------------------------------------------
+
+class TestOpenHappy:
+    """정상 실행 시나리오."""
+
+    def test_open_existing_problem_dir(self, boj_env, fixture_path):
+        """문제 폴더가 존재하면 에디터를 열고 exit 0."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+
+        # BOJ_EDITOR=true (boj_env 기본값) → 항상 성공하는 에디터
+        result = run_boj(env, "open", "99999")
+
+        assert result.returncode == 0, (
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "에디터로 열었습니다" in result.stderr
+
+    def test_open_with_editor_flag(self, boj_env, fixture_path):
+        """O3: --editor 플래그로 에디터를 override한다."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+
+        # "true"는 어디서든 사용 가능한 명령어
+        result = run_boj(env, "open", "99999", "--editor", "true")
+
+        assert result.returncode == 0, (
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Error Paths
+# ---------------------------------------------------------------------------
+
+class TestOpenErrors:
+    """에러 경로 시나리오."""
+
+    def test_exits_one_when_problem_dir_missing(self, boj_env):
+        """O1: 문제 폴더 없으면 exit 1 + boj make 안내."""
+        _, env = boj_env
+
+        result = run_boj(env, "open", "99999")
+
+        assert result.returncode != 0
+        assert "Error:" in result.stderr
+        assert "boj make" in result.stderr
+
+    def test_exits_one_when_editor_not_in_path(self, boj_env, fixture_path):
+        """O4: 에디터가 PATH에 없으면 exit 1."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+
+        # 존재하지 않는 에디터
+        result = run_boj(env, "open", "99999", "--editor", "nonexistent-editor-xyz")
+
+        assert result.returncode != 0
+        assert "Error:" in result.stderr
+        assert "찾을 수 없습니다" in result.stderr
+
+    def test_exits_one_when_editor_empty(self, boj_env, fixture_path):
+        """O2: 에디터 미설정 시 exit 1."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+
+        # BOJ_EDITOR를 빈 문자열로 설정
+        env["BOJ_EDITOR"] = ""
+
+        result = run_boj(env, "open", "99999")
+
+        assert result.returncode != 0
+        assert "Error:" in result.stderr

--- a/tests/unit/test_open.py
+++ b/tests/unit/test_open.py
@@ -1,0 +1,224 @@
+"""src/core/open.py 단위 테스트.
+
+Issue #66 — boj open Python 마이그레이션.
+edge-cases O1-O4 커버리지.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.exceptions import BojError
+
+
+# ---------------------------------------------------------------------------
+# find_or_create_problem_dir
+# ---------------------------------------------------------------------------
+
+class TestFindOrCreateProblemDir:
+    """문제 폴더 검색."""
+
+    def test_returns_path_when_dir_exists(self, tmp_path):
+        """문제 폴더가 존재하면 경로를 반환한다."""
+        from src.core.open import find_or_create_problem_dir
+
+        prob_dir = tmp_path / "99999-두수의합"
+        prob_dir.mkdir()
+
+        result = find_or_create_problem_dir("99999", base_dir=tmp_path)
+
+        assert result == prob_dir
+
+    def test_raises_when_dir_missing(self, tmp_path):
+        """O1: 문제 폴더가 없으면 BojError를 발생시킨다."""
+        from src.core.open import find_or_create_problem_dir
+
+        with pytest.raises(BojError, match="문제 폴더가 없습니다"):
+            find_or_create_problem_dir("99999", base_dir=tmp_path)
+
+    def test_raises_message_suggests_make(self, tmp_path):
+        """O1: 에러 메시지에 boj make 안내가 포함된다."""
+        from src.core.open import find_or_create_problem_dir
+
+        with pytest.raises(BojError, match="boj make"):
+            find_or_create_problem_dir("12345", base_dir=tmp_path)
+
+    def test_uses_config_when_base_dir_none(self, tmp_path):
+        """base_dir이 None이면 config에서 solution_root를 읽는다."""
+        from src.core.open import find_or_create_problem_dir
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.config_get", return_value=str(tmp_path)):
+            result = find_or_create_problem_dir("99999")
+
+        assert result == prob_dir
+
+
+# ---------------------------------------------------------------------------
+# open_in_editor
+# ---------------------------------------------------------------------------
+
+class TestOpenInEditor:
+    """에디터로 문제 폴더 열기."""
+
+    def test_calls_popen_with_editor_and_dir(self, tmp_path):
+        """에디터 명령어와 폴더 경로로 Popen을 호출한다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value="/usr/bin/code"), \
+             patch("src.core.open.subprocess.Popen") as mock_popen:
+            open_in_editor(prob_dir, "code")
+
+        mock_popen.assert_called_once_with(
+            ["code", str(prob_dir)],
+            cwd=str(prob_dir),
+        )
+
+    def test_handles_editor_with_args(self, tmp_path):
+        """에디터 명령어에 인수가 포함된 경우를 처리한다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value="/usr/bin/code"), \
+             patch("src.core.open.subprocess.Popen") as mock_popen:
+            open_in_editor(prob_dir, "code --new-window")
+
+        mock_popen.assert_called_once_with(
+            ["code", "--new-window", str(prob_dir)],
+            cwd=str(prob_dir),
+        )
+
+    def test_raises_when_editor_empty(self, tmp_path):
+        """O2: 에디터가 비어있으면 BojError를 발생시킨다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with pytest.raises(BojError, match="에디터가 설정되지 않았습니다"):
+            open_in_editor(prob_dir, "")
+
+    def test_raises_when_editor_none(self, tmp_path):
+        """O2: 에디터가 None이면 BojError를 발생시킨다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with pytest.raises(BojError, match="에디터가 설정되지 않았습니다"):
+            open_in_editor(prob_dir, None)
+
+    def test_raises_when_editor_whitespace_only(self, tmp_path):
+        """O2: 에디터가 공백만 있으면 BojError를 발생시킨다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with pytest.raises(BojError, match="에디터가 설정되지 않았습니다"):
+            open_in_editor(prob_dir, "   ")
+
+    def test_raises_when_editor_not_in_path(self, tmp_path):
+        """O4: 에디터가 PATH에 없으면 BojError를 발생시킨다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value=None):
+            with pytest.raises(BojError, match="찾을 수 없습니다"):
+                open_in_editor(prob_dir, "nonexistent-editor")
+
+    def test_error_message_includes_editor_name(self, tmp_path):
+        """O4: 에러 메시지에 에디터 이름이 포함된다."""
+        from src.core.open import open_in_editor
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value=None):
+            with pytest.raises(BojError, match="mycustom"):
+                open_in_editor(prob_dir, "mycustom")
+
+
+# ---------------------------------------------------------------------------
+# open_problem (통합 단위)
+# ---------------------------------------------------------------------------
+
+class TestOpenProblem:
+    """open_problem() 전체 흐름."""
+
+    def test_opens_existing_dir_with_editor(self, tmp_path):
+        """정상 경로: 폴더 존재 + 에디터 설정 → Popen 호출."""
+        from src.core.open import open_problem
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value="/usr/bin/code"), \
+             patch("src.core.open.subprocess.Popen") as mock_popen:
+            result = open_problem(
+                "99999", editor="code", base_dir=tmp_path,
+            )
+
+        assert result == prob_dir
+        mock_popen.assert_called_once()
+
+    def test_editor_override_takes_precedence(self, tmp_path):
+        """O3: --editor flag가 config보다 우선한다."""
+        from src.core.open import open_problem
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value="/usr/bin/vim"), \
+             patch("src.core.open.subprocess.Popen") as mock_popen, \
+             patch("src.core.open.config_get", return_value="code"):
+            open_problem("99999", editor="vim", base_dir=tmp_path)
+
+        # vim이 사용되어야 함 (code가 아님)
+        args = mock_popen.call_args[0][0]
+        assert args[0] == "vim"
+
+    def test_uses_config_editor_when_no_override(self, tmp_path):
+        """에디터 미지정 시 config에서 읽는다."""
+        from src.core.open import open_problem
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value="/usr/bin/cursor"), \
+             patch("src.core.open.subprocess.Popen") as mock_popen, \
+             patch("src.core.open.config_get", return_value="cursor"):
+            open_problem("99999", editor=None, base_dir=tmp_path)
+
+        args = mock_popen.call_args[0][0]
+        assert args[0] == "cursor"
+
+    def test_raises_when_dir_missing(self, tmp_path):
+        """O1: 폴더 없으면 BojError."""
+        from src.core.open import open_problem
+
+        with pytest.raises(BojError, match="문제 폴더가 없습니다"):
+            open_problem("99999", editor="code", base_dir=tmp_path)
+
+    def test_raises_when_editor_not_found(self, tmp_path):
+        """O4: 에디터 PATH 없으면 BojError."""
+        from src.core.open import open_problem
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        with patch("src.core.open.shutil.which", return_value=None):
+            with pytest.raises(BojError, match="찾을 수 없습니다"):
+                open_problem(
+                    "99999", editor="nonexistent", base_dir=tmp_path,
+                )


### PR DESCRIPTION
## Summary
- `boj open` 명령어를 Bash(`src/commands/open.sh`)에서 Python(`src/core/open.py` + `src/cli/boj_open.py`)으로 마이그레이션
- 디스패처(`src/boj`)에 Python 라우팅 추가 (Bash fallback 유지)
- 단위 테스트 + 통합 테스트 추가

## Changes
- `src/core/open.py`: 순수 로직 (find_or_create_problem_dir, open_editor)
- `src/cli/boj_open.py`: CLI 래퍼 (argparse)
- `tests/unit/test_open.py`: 단위 테스트 (O1-O4 엣지케이스)
- `tests/integration/test_open_py.py`: 통합 테스트
- `src/boj`: open 케이스 Python 라우팅 추가

## Test plan
- [x] `python3 -m pytest tests/ -v` — 354 passed, 1 skipped, 0 failures
- [ ] `BOJ_ROOT=. src/boj open 99999` — 수동 확인

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>