### PR TITLE
feat(commit): migrate boj commit from Bash to Python [#68]

### DIFF
--- a/src/boj
+++ b/src/boj
@@ -158,7 +158,22 @@ case "$SUBCOMMAND" in
       exec "$CMD_SCRIPT" "$ROOT" "$PROBLEM_NUM" "${@:3}"
     fi
     ;;
-  commit|submit)
+  commit)
+    # Python 마이그레이션 (#68): src/cli/boj_commit.py로 라우팅
+    COMMIT_PY="$ROOT/src/cli/boj_commit.py"
+    if [[ -f "$COMMIT_PY" ]]; then
+      shift  # subcommand 제거
+      PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" exec python3 "$COMMIT_PY" "$@"
+    else
+      # fallback: 기존 Bash
+      if [[ ! -x "$CMD_SCRIPT" ]]; then
+        echo "Error: $CMD_SCRIPT 를 찾을 수 없거나 실행할 수 없습니다." >&2
+        exit 1
+      fi
+      exec "$CMD_SCRIPT" "$ROOT" "$PROBLEM_NUM" "${@:3}"
+    fi
+    ;;
+  submit)
     if [[ ! -x "$CMD_SCRIPT" ]]; then
       echo "Error: $CMD_SCRIPT 를 찾을 수 없거나 실행할 수 없습니다." >&2
       echo "  (chmod +x $CMD_SCRIPT 로 실행 권한을 추가해보세요)" >&2

--- a/src/cli/boj_commit.py
+++ b/src/cli/boj_commit.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""boj commit CLI 래퍼 -- 인수 파싱 + 출력 포매팅.
+
+Issue #68 -- commit.sh Python 마이그레이션.
+
+사용법:
+    python -m src.cli.boj_commit <문제번호> [--message MSG] [--no-stats] [--no-push]
+    또는 boj 디스패처에서 호출.
+"""
+
+import argparse
+import sys
+
+from src.core.commit import commit
+from src.core.exceptions import BojError
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI 인수를 파싱한다.
+
+    Args:
+        argv: 인수 리스트. None이면 sys.argv[1:] 사용.
+
+    Returns:
+        파싱된 Namespace.
+    """
+    parser = argparse.ArgumentParser(
+        prog="boj commit",
+        description="문제 폴더 파일을 git commit (BOJ 통계 포함)",
+    )
+    parser.add_argument(
+        "problem_num",
+        help="문제 번호 (예: 99999)",
+    )
+    parser.add_argument(
+        "--message", "-m",
+        default=None,
+        help="커밋 메시지 직접 지정",
+    )
+    parser.add_argument(
+        "--no-stats",
+        action="store_true",
+        default=False,
+        help="BOJ 통계 조회 스킵",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        default=False,
+        help="push 프롬프트 스킵",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """boj commit 메인 진입점.
+
+    Args:
+        argv: CLI 인수. None이면 sys.argv[1:].
+
+    Returns:
+        exit code (0=성공, 1=에러).
+    """
+    args = parse_args(argv)
+
+    try:
+        msg = commit(
+            problem_num=args.problem_num,
+            custom_message=args.message,
+            no_stats=args.no_stats,
+        )
+
+        print(f"커밋 메시지: {msg}")
+
+        # push 프롬프트: TTY이고 --no-push가 아닌 경우에만
+        if not args.no_push and sys.stdin.isatty():
+            try:
+                answer = input("GitHub에 푸시하시겠습니까? (y/N): ")
+                if answer.strip().lower() in ("y", "yes"):
+                    import subprocess
+                    result = subprocess.run(
+                        ["git", "push"],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    if result.returncode == 0:
+                        print("푸시 완료!")
+                    else:
+                        print(
+                            f"푸시 실패: {result.stderr.strip()}",
+                            file=sys.stderr,
+                        )
+                else:
+                    print(
+                        "푸시를 건너뛰었습니다. "
+                        "나중에 'git push'로 푸시하세요."
+                    )
+            except (EOFError, KeyboardInterrupt):
+                print("\n푸시를 건너뛰었습니다.")
+
+        return 0
+
+    except BojError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    except KeyboardInterrupt:
+        print("\n중단되었습니다.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/commit.py
+++ b/src/core/commit.py
@@ -1,0 +1,392 @@
+"""boj commit 핵심 로직 -- BOJ 통계 + git 자동 커밋.
+
+Issue #68 -- commit.sh Python 마이그레이션.
+edge-cases CT1-CT9 커버리지.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+
+from src.core.config import config_get, find_problem_dir
+from src.core.exceptions import BojError
+
+# ---------------------------------------------------------------------------
+# 상수
+# ---------------------------------------------------------------------------
+
+USER_AGENT = "Mozilla/5.0 (compatible; boj-agent/1.0)"
+BOJ_STATUS_URL = "https://www.acmicpc.net/status"
+STATS_TIMEOUT_SEC = 5
+
+# 화이트리스트: 문제 폴더에서 staging할 파일 패턴
+_WHITELIST_FILES = [
+    "README.md",
+    "Solution.java",
+    "solution.py",
+    "Solution.py",
+    "Solution.cpp",
+    "Solution.c",
+    "Solution.kt",
+    "Solution.go",
+    "test/test_cases.json",
+    "test/Parse.java",
+    "test/Parse.py",
+    "test/Parse.cpp",
+    "test/Parse.c",
+    "test/Parse.kt",
+    "test/Parse.go",
+    "submit/REVIEW.md",
+    "submit/Submit.java",
+    "submit/Submit.py",
+    "submit/Submit.cpp",
+    "submit/Submit.c",
+    "submit/Submit.kt",
+    "submit/Submit.go",
+]
+
+
+# ---------------------------------------------------------------------------
+# check_git_repo
+# ---------------------------------------------------------------------------
+
+def check_git_repo(cwd: Path | None = None) -> None:
+    """git repo인지 확인한다. 아니면 BojError.
+
+    Args:
+        cwd: 확인할 디렉터리. None이면 현재 디렉터리.
+
+    Raises:
+        BojError: git 저장소가 아닌 경우 (CT2).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            raise BojError("git 저장소가 아닙니다.")
+    except FileNotFoundError:
+        raise BojError("git을 찾을 수 없습니다.")
+
+
+# ---------------------------------------------------------------------------
+# check_git_email
+# ---------------------------------------------------------------------------
+
+def check_git_email(cwd: Path | None = None) -> None:
+    """git user.email 설정을 확인한다. 없으면 BojError.
+
+    Args:
+        cwd: 확인할 디렉터리. None이면 현재 디렉터리.
+
+    Raises:
+        BojError: git user.email이 설정되지 않은 경우 (CT8).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.email"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        email = result.stdout.strip()
+        if not email:
+            raise BojError(
+                "git user.email이 설정되지 않았습니다. "
+                "boj setup 또는 git config --global user.email 실행."
+            )
+    except FileNotFoundError:
+        raise BojError("git을 찾을 수 없습니다.")
+
+
+# ---------------------------------------------------------------------------
+# fetch_boj_stats
+# ---------------------------------------------------------------------------
+
+def fetch_boj_stats(
+    problem_id: str,
+    session: str,
+    username: str,
+) -> str:
+    """BOJ 통계(메모리/시간)를 조회한다.
+
+    실패 시 실패 사유 문자열을 반환한다 (non-fatal).
+
+    Args:
+        problem_id: 문제 번호.
+        session: BOJ 세션 쿠키 값.
+        username: BOJ 사용자 ID.
+
+    Returns:
+        "[v Nms NKB]" 또는 "[BOJ 통계: 실패 사유]" 형태의 문자열.
+    """
+    if not session:
+        return "[BOJ 통계: 세션 없음]"
+
+    if not username:
+        return "[BOJ 통계: 사용자 ID 없음]"
+
+    url = (
+        f"{BOJ_STATUS_URL}"
+        f"?problem_id={problem_id}"
+        f"&user_id={username}"
+        f"&result_id=4"
+    )
+
+    try:
+        resp = requests.get(
+            url,
+            headers={
+                "Cookie": f"OnlineJudge={session}; bojautologin={session}",
+                "User-Agent": USER_AGENT,
+            },
+            timeout=STATS_TIMEOUT_SEC,
+        )
+    except requests.exceptions.RequestException:
+        return "[BOJ 통계: 네트워크 오류]"
+
+    if not resp.text:
+        return "[BOJ 통계: 응답 없음]"
+
+    # BeautifulSoup으로 메모리/시간 파싱
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    # status 테이블에서 메모리(KB)와 시간(ms) td 추출
+    memory = _parse_stat_td(soup, "KB")
+    time_ms = _parse_stat_td(soup, "ms")
+
+    if memory is not None and time_ms is not None:
+        return f"[✓ {time_ms}ms {memory}KB]"
+
+    # Accepted 결과 확인
+    if "맞았습니다" in resp.text or "Accepted" in resp.text:
+        return "[BOJ 통계: 파싱 실패]"
+
+    return "[BOJ 통계: Accepted 없음]"
+
+
+def _parse_stat_td(soup: BeautifulSoup, unit: str) -> str | None:
+    """BeautifulSoup에서 특정 단위의 td 값을 추출한다.
+
+    Args:
+        soup: BeautifulSoup 객체.
+        unit: 단위 문자열 (예: "KB", "ms").
+
+    Returns:
+        숫자 문자열 또는 None.
+    """
+    for td in soup.find_all("td"):
+        text = td.get_text(strip=True)
+        if text.endswith(f" {unit}"):
+            val = text[: -len(f" {unit}")]
+            if val.isdigit():
+                return val
+    return None
+
+
+# ---------------------------------------------------------------------------
+# build_commit_message
+# ---------------------------------------------------------------------------
+
+def build_commit_message(
+    problem_name: str,
+    stats: str,
+    custom_message: str | None = None,
+) -> str:
+    """커밋 메시지를 생성한다.
+
+    Args:
+        problem_name: 문제 폴더 이름 (예: "99999-두수의합").
+        stats: BOJ 통계 문자열.
+        custom_message: 사용자 지정 커밋 메시지. None이면 자동 생성.
+
+    Returns:
+        커밋 메시지 문자열.
+    """
+    if custom_message:
+        return custom_message
+
+    return f"{problem_name} 풀이 완료 {stats}"
+
+
+# ---------------------------------------------------------------------------
+# stage_problem_files
+# ---------------------------------------------------------------------------
+
+def stage_problem_files(
+    problem_dir: Path,
+    cwd: Path | None = None,
+) -> list[str]:
+    """화이트리스트 파일을 staging한다. 존재하는 파일만.
+
+    Args:
+        problem_dir: 문제 폴더 절대 경로.
+        cwd: git 명령 실행 디렉터리 (repo root). None이면 현재 디렉터리.
+
+    Returns:
+        staging된 파일의 상대 경로 리스트.
+    """
+    problem_name = problem_dir.name
+    files_to_add = []
+
+    for rel_path in _WHITELIST_FILES:
+        full_path = problem_dir / rel_path
+        if full_path.exists():
+            files_to_add.append(f"{problem_name}/{rel_path}")
+
+    if not files_to_add:
+        return []
+
+    try:
+        subprocess.run(
+            ["git", "add"] + files_to_add,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # 일부 파일 스테이징 실패 -- Warning만 출력
+        print(
+            "Warning: 일부 파일 스테이징 실패. 수동으로 git add를 확인하세요.",
+            file=sys.stderr,
+        )
+
+    return files_to_add
+
+
+# ---------------------------------------------------------------------------
+# has_staged_changes
+# ---------------------------------------------------------------------------
+
+def has_staged_changes(cwd: Path | None = None) -> bool:
+    """staging area에 변경사항이 있는지 확인한다.
+
+    Args:
+        cwd: git 명령 실행 디렉터리. None이면 현재 디렉터리.
+
+    Returns:
+        변경사항이 있으면 True.
+    """
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=cwd,
+        capture_output=True,
+        timeout=5,
+    )
+    # returncode 0 = no diff (clean), 1 = has diff
+    return result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# git_commit
+# ---------------------------------------------------------------------------
+
+def git_commit(message: str, cwd: Path | None = None) -> None:
+    """git commit을 실행한다.
+
+    Args:
+        message: 커밋 메시지.
+        cwd: git 명령 실행 디렉터리. None이면 현재 디렉터리.
+
+    Raises:
+        BojError: git commit 실패 시.
+    """
+    result = subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise BojError(
+            f"git commit 실패: {result.stderr.strip()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# commit (메인 함수)
+# ---------------------------------------------------------------------------
+
+def commit(
+    problem_num: str,
+    custom_message: str | None = None,
+    no_stats: bool = False,
+    solution_root: Path | None = None,
+    cwd: Path | None = None,
+) -> str:
+    """boj commit의 핵심 로직.
+
+    Args:
+        problem_num: 문제 번호.
+        custom_message: 사용자 지정 커밋 메시지.
+        no_stats: True이면 BOJ 통계 조회를 건너뛴다.
+        solution_root: 풀이 루트 디렉터리. None이면 config에서 읽음.
+        cwd: git 명령 실행 디렉터리. None이면 solution_root 사용.
+
+    Returns:
+        커밋 메시지 문자열.
+
+    Raises:
+        BojError: git repo가 아니거나, email 미설정이거나,
+                  문제 폴더를 찾을 수 없는 경우.
+    """
+    # 루트 경로 결정
+    if solution_root is None:
+        root_str = config_get("solution_root", "")
+        solution_root = Path(root_str) if root_str else Path.cwd()
+
+    if cwd is None:
+        cwd = solution_root
+
+    # CT2: git repo 확인
+    check_git_repo(cwd)
+
+    # CT8: git email 확인
+    check_git_email(cwd)
+
+    # CT1: 문제 폴더 찾기
+    problem_dir_str = find_problem_dir(str(solution_root), problem_num)
+    if problem_dir_str is None:
+        raise BojError(
+            f"'{problem_num}'로 시작하는 폴더를 찾을 수 없습니다."
+        )
+    problem_dir = Path(problem_dir_str)
+    problem_name = problem_dir.name
+
+    # BOJ 통계 조회
+    if no_stats:
+        stats = "[BOJ 통계: 스킵]"
+    else:
+        session = config_get("session", "")
+        username = config_get("username", "")
+        stats = fetch_boj_stats(problem_num, session, username)
+
+    # 커밋 메시지 생성
+    msg = build_commit_message(problem_name, stats, custom_message)
+
+    # 파일 staging
+    stage_problem_files(problem_dir, cwd)
+
+    # CT3: 변경사항 확인
+    if not has_staged_changes(cwd):
+        print(
+            "Warning: 커밋할 변경사항이 없습니다.",
+            file=sys.stderr,
+        )
+        return msg
+
+    # 커밋 실행
+    git_commit(msg, cwd)
+
+    return msg

--- a/tests/integration/test_commit_py.py
+++ b/tests/integration/test_commit_py.py
@@ -1,0 +1,177 @@
+"""boj commit 통합 테스트 -- CLI 디스패처 경유.
+
+Issue #68 -- commit.sh Python 마이그레이션.
+edge-cases CT1-CT9 커버리지 (integration 레벨).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_boj, setup_problem_dir
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
+
+
+def _init_git(tmp_path, env):
+    """git init + empty initial commit으로 커밋 가능한 상태를 만든다.
+
+    문제 폴더 파일은 staging하지 않는다 (boj commit이 staging할 수 있도록).
+    """
+    subprocess.run(
+        ["git", "commit", "-m", "initial", "--allow-empty"],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy Path
+# ---------------------------------------------------------------------------
+
+class TestCommitHappy:
+    """정상 커밋 시나리오."""
+
+    def test_commit_with_no_stats(self, boj_env, fixture_path):
+        """--no-stats로 통계 조회 없이 커밋한다."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+        _init_git(tmp_path, env)
+
+        result = run_boj(env, "commit", "99999", "--no-stats", "--no-push")
+
+        assert result.returncode == 0, (
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "커밋 메시지" in result.stdout
+
+        # git log 확인
+        log = subprocess.run(
+            ["git", "log", "--oneline", "-1"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert "풀이 완료" in log.stdout
+
+    def test_commit_with_custom_message(self, boj_env, fixture_path):
+        """--message로 커밋 메시지를 직접 지정한다."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+        _init_git(tmp_path, env)
+
+        result = run_boj(
+            env, "commit", "99999",
+            "--no-stats", "--no-push",
+            "-m", "my custom msg",
+        )
+
+        assert result.returncode == 0, (
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+        log = subprocess.run(
+            ["git", "log", "--oneline", "-1"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert "my custom msg" in log.stdout
+
+
+# ---------------------------------------------------------------------------
+# Error Cases
+# ---------------------------------------------------------------------------
+
+class TestCommitErrors:
+    """에러 시나리오."""
+
+    def test_error_when_problem_not_found(self, boj_env):
+        """CT1: 문제 폴더가 없으면 에러를 반환한다."""
+        tmp_path, env = boj_env
+        _init_git(tmp_path, env)
+
+        result = run_boj(env, "commit", "88888", "--no-stats", "--no-push")
+
+        assert result.returncode == 1
+        assert "찾을 수 없습니다" in result.stderr
+
+    def test_error_when_not_git_repo(self, boj_env, fixture_path):
+        """CT2: git repo가 아니면 에러를 반환한다."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+
+        # .git 디렉터리 삭제
+        git_dir = tmp_path / ".git"
+        if git_dir.exists():
+            shutil.rmtree(git_dir)
+
+        result = run_boj(env, "commit", "99999", "--no-stats", "--no-push")
+
+        assert result.returncode == 1
+        assert "git" in result.stderr.lower()
+
+    def test_warning_when_nothing_to_commit(self, boj_env, fixture_path):
+        """CT3: 변경사항이 없으면 Warning을 출력하고 정상 종료한다."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+        _init_git(tmp_path, env)
+
+        # 먼저 한 번 커밋하여 변경사항 소진
+        run_boj(env, "commit", "99999", "--no-stats", "--no-push")
+
+        # 다시 커밋 시도 -- 변경사항 없음
+        result = run_boj(env, "commit", "99999", "--no-stats", "--no-push")
+
+        assert result.returncode == 0
+        assert "변경사항이 없습니다" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# CT9: pre-staged 변경사항
+# ---------------------------------------------------------------------------
+
+class TestCommitPreStaged:
+    """CT9: 기존 staged 변경사항과 함께 커밋."""
+
+    def test_preserves_pre_staged_changes(self, boj_env, fixture_path):
+        """기존 staged 파일 + 문제 폴더 파일이 함께 커밋된다."""
+        tmp_path, env = boj_env
+        fix = fixture_path(99999)
+        setup_problem_dir(tmp_path, fix, lang="java")
+        _init_git(tmp_path, env)
+
+        # 문제 폴더 외부에 파일 추가 후 staging
+        (tmp_path / "extra.txt").write_text("extra content")
+        subprocess.run(
+            ["git", "add", "extra.txt"],
+            cwd=tmp_path,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        result = run_boj(env, "commit", "99999", "--no-stats", "--no-push")
+
+        assert result.returncode == 0
+
+        # extra.txt가 커밋에 포함되었는지 확인
+        show = subprocess.run(
+            ["git", "show", "--stat", "HEAD"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert "extra.txt" in show.stdout

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -1,0 +1,356 @@
+"""src/core/commit.py 단위 테스트.
+
+Issue #68 -- boj commit Python 마이그레이션.
+edge-cases CT1-CT9 커버리지.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.commit import (
+    build_commit_message,
+    check_git_email,
+    check_git_repo,
+    fetch_boj_stats,
+    git_commit,
+    has_staged_changes,
+    stage_problem_files,
+)
+from src.core.exceptions import BojError
+
+
+# ---------------------------------------------------------------------------
+# check_git_repo
+# ---------------------------------------------------------------------------
+
+class TestCheckGitRepo:
+    """git repo 확인."""
+
+    def test_passes_in_git_repo(self, tmp_path):
+        """정상: git repo이면 예외 없이 통과한다."""
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # 예외 없이 통과
+        check_git_repo(tmp_path)
+
+    def test_raises_when_not_git_repo(self, tmp_path):
+        """CT2: git repo가 아니면 BojError를 발생시킨다."""
+        with pytest.raises(BojError, match="git 저장소가 아닙니다"):
+            check_git_repo(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# check_git_email
+# ---------------------------------------------------------------------------
+
+class TestCheckGitEmail:
+    """git user.email 확인."""
+
+    def test_passes_when_email_set(self, tmp_path):
+        """정상: email이 설정되어 있으면 통과한다."""
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # 예외 없이 통과
+        check_git_email(tmp_path)
+
+    def test_raises_when_email_not_set(self, tmp_path, monkeypatch):
+        """CT8: email이 설정되지 않으면 BojError를 발생시킨다."""
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        # 글로벌 config 상속을 차단하여 email이 없는 상태를 보장
+        monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        with pytest.raises(BojError, match="user.email"):
+            check_git_email(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# fetch_boj_stats
+# ---------------------------------------------------------------------------
+
+class TestFetchBojStats:
+    """BOJ 통계 조회."""
+
+    def test_returns_stats_on_success(self):
+        """정상: 메모리/시간 파싱 성공 시 통계 문자열을 반환한다."""
+        html = """
+        <html><body>
+        <table>
+        <tr><td>12345</td><td>맞았습니다</td><td>1234 KB</td><td>56 ms</td></tr>
+        </table>
+        </body></html>
+        """
+        mock_resp = MagicMock()
+        mock_resp.text = html
+
+        with patch("src.core.commit.requests.get", return_value=mock_resp):
+            result = fetch_boj_stats("1000", "session123", "testuser")
+
+        assert result == "[✓ 56ms 1234KB]"
+
+    def test_returns_no_session_when_empty(self):
+        """CT4 변형: 세션이 비어있으면 세션 없음을 반환한다."""
+        result = fetch_boj_stats("1000", "", "testuser")
+
+        assert "세션 없음" in result
+
+    def test_returns_no_username_when_empty(self):
+        """CT4: username이 비어있으면 사용자 ID 없음을 반환한다."""
+        result = fetch_boj_stats("1000", "session123", "")
+
+        assert "사용자 ID 없음" in result
+
+    def test_returns_network_error_on_timeout(self):
+        """CT6: 타임아웃 시 네트워크 오류를 반환한다."""
+        import requests
+
+        with patch(
+            "src.core.commit.requests.get",
+            side_effect=requests.exceptions.Timeout("timeout"),
+        ):
+            result = fetch_boj_stats("1000", "session123", "testuser")
+
+        assert "네트워크 오류" in result
+
+    def test_returns_no_accepted_when_not_found(self):
+        """CT7: Accepted 제출이 없으면 Accepted 없음을 반환한다."""
+        html = "<html><body><table><tr><td>틀렸습니다</td></tr></table></body></html>"
+        mock_resp = MagicMock()
+        mock_resp.text = html
+
+        with patch("src.core.commit.requests.get", return_value=mock_resp):
+            result = fetch_boj_stats("1000", "session123", "testuser")
+
+        assert "Accepted 없음" in result
+
+    def test_returns_parse_error_when_accepted_but_no_stats(self):
+        """CT5 변형: 맞았습니다가 있으나 메모리/시간 파싱 실패."""
+        html = "<html><body><td>맞았습니다</td></body></html>"
+        mock_resp = MagicMock()
+        mock_resp.text = html
+
+        with patch("src.core.commit.requests.get", return_value=mock_resp):
+            result = fetch_boj_stats("1000", "session123", "testuser")
+
+        assert "파싱 실패" in result
+
+    def test_returns_empty_response(self):
+        """응답이 비어있으면 응답 없음을 반환한다."""
+        mock_resp = MagicMock()
+        mock_resp.text = ""
+
+        with patch("src.core.commit.requests.get", return_value=mock_resp):
+            result = fetch_boj_stats("1000", "session123", "testuser")
+
+        assert "응답 없음" in result
+
+
+# ---------------------------------------------------------------------------
+# build_commit_message
+# ---------------------------------------------------------------------------
+
+class TestBuildCommitMessage:
+    """커밋 메시지 생성."""
+
+    def test_auto_message_with_stats(self):
+        """정상: 자동 메시지에 문제 이름과 통계가 포함된다."""
+        msg = build_commit_message(
+            "99999-두수의합",
+            "[✓ 56ms 1234KB]",
+        )
+
+        assert "99999-두수의합" in msg
+        assert "풀이 완료" in msg
+        assert "56ms" in msg
+
+    def test_auto_message_without_stats(self):
+        """통계 실패 시에도 자동 메시지가 생성된다."""
+        msg = build_commit_message(
+            "99999-두수의합",
+            "[BOJ 통계: 네트워크 오류]",
+        )
+
+        assert "99999-두수의합" in msg
+        assert "네트워크 오류" in msg
+
+    def test_custom_message_overrides(self):
+        """사용자 지정 메시지가 우선한다."""
+        msg = build_commit_message(
+            "99999-두수의합",
+            "[✓ 56ms 1234KB]",
+            custom_message="my custom message",
+        )
+
+        assert msg == "my custom message"
+
+
+# ---------------------------------------------------------------------------
+# stage_problem_files
+# ---------------------------------------------------------------------------
+
+class TestStageProblemFiles:
+    """문제 폴더 파일 staging."""
+
+    def test_stages_existing_files(self, tmp_path):
+        """존재하는 화이트리스트 파일만 staging한다."""
+        # git init
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Tester"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # 문제 폴더 생성
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+        (prob_dir / "README.md").write_text("# Test")
+        (prob_dir / "Solution.java").write_text("class S {}")
+        test_dir = prob_dir / "test"
+        test_dir.mkdir()
+        (test_dir / "test_cases.json").write_text('{"testCases": []}')
+
+        result = stage_problem_files(prob_dir, cwd=tmp_path)
+
+        assert "99999-test/README.md" in result
+        assert "99999-test/Solution.java" in result
+        assert "99999-test/test/test_cases.json" in result
+
+    def test_returns_empty_when_no_files(self, tmp_path):
+        """화이트리스트 파일이 없으면 빈 리스트를 반환한다."""
+        prob_dir = tmp_path / "99999-empty"
+        prob_dir.mkdir()
+
+        result = stage_problem_files(prob_dir, cwd=tmp_path)
+
+        assert result == []
+
+    def test_ignores_nonwhitelist_files(self, tmp_path):
+        """화이트리스트에 없는 파일은 staging하지 않는다."""
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+        (prob_dir / "random.txt").write_text("not whitelisted")
+        (prob_dir / "README.md").write_text("# Test")
+
+        result = stage_problem_files(prob_dir, cwd=tmp_path)
+
+        assert "99999-test/README.md" in result
+        assert "99999-test/random.txt" not in result
+
+
+# ---------------------------------------------------------------------------
+# has_staged_changes
+# ---------------------------------------------------------------------------
+
+class TestHasStagedChanges:
+    """staging area 변경사항 확인."""
+
+    def test_returns_false_when_clean(self, tmp_path):
+        """staging area가 비어있으면 False를 반환한다."""
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        assert has_staged_changes(tmp_path) is False
+
+    def test_returns_true_when_staged(self, tmp_path):
+        """staging된 파일이 있으면 True를 반환한다."""
+        subprocess.run(
+            ["git", "init", "-q"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(
+            ["git", "add", "file.txt"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        assert has_staged_changes(tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# git_commit
+# ---------------------------------------------------------------------------
+
+class TestGitCommit:
+    """git commit 실행."""
+
+    def test_commits_successfully(self, tmp_path):
+        """정상: staging된 파일을 커밋한다."""
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True, capture_output=True)
+
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(["git", "add", "file.txt"], cwd=tmp_path, check=True, capture_output=True)
+
+        git_commit("test commit", cwd=tmp_path)
+
+        # 커밋 확인
+        log = subprocess.run(
+            ["git", "log", "--oneline", "-1"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "test commit" in log.stdout
+
+    def test_raises_when_nothing_staged(self, tmp_path):
+        """커밋할 것이 없으면 BojError를 발생시킨다."""
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True, capture_output=True)
+
+        with pytest.raises(BojError, match="commit 실패"):
+            git_commit("empty commit", cwd=tmp_path)


### PR DESCRIPTION
## Summary
- `boj commit` 명령어를 Bash(`src/commands/commit.sh`)에서 Python(`src/core/commit.py` + `src/cli/boj_commit.py`)으로 마이그레이션
- 디스패처(`src/boj`)에 Python 라우팅 추가 (Bash fallback 유지)
- 단위 테스트 + 통합 테스트 추가

## Changes
- `src/core/commit.py`: 순수 로직 (check_git_repo, check_git_email, fetch_boj_stats, build_commit_message, stage_problem_files, git_commit)
- `src/cli/boj_commit.py`: CLI 래퍼 (argparse)
- `tests/unit/test_commit.py`: 단위 테스트
- `tests/integration/test_commit_py.py`: 통합 테스트
- `src/boj`: commit 케이스 Python 라우팅 추가

## Test plan
- [x] `python3 -m pytest tests/ -v` — 406 passed, 1 skipped, 0 failures
- [ ] `BOJ_ROOT=. src/boj commit 99999` — 수동 확인

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>