### PR TITLE
fix(commit): lazy import requests/bs4 for CI compatibility [#68]

### DIFF
--- a/src/core/commit.py
+++ b/src/core/commit.py
@@ -8,9 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import requests
-from bs4 import BeautifulSoup
-
 from src.core.config import config_get, find_problem_dir
 from src.core.exceptions import BojError
 
@@ -142,6 +139,11 @@ def fetch_boj_stats(
     )
 
     try:
+        import requests  # lazy import: CI에서 미설치 가능
+    except ImportError:
+        return "[BOJ 통계: requests 모듈 없음]"
+
+    try:
         resp = requests.get(
             url,
             headers={
@@ -155,6 +157,11 @@ def fetch_boj_stats(
 
     if not resp.text:
         return "[BOJ 통계: 응답 없음]"
+
+    try:
+        from bs4 import BeautifulSoup  # lazy import: CI에서 미설치 가능
+    except ImportError:
+        return "[BOJ 통계: bs4 모듈 없음]"
 
     # BeautifulSoup으로 메모리/시간 파싱
     soup = BeautifulSoup(resp.text, "html.parser")
@@ -173,7 +180,7 @@ def fetch_boj_stats(
     return "[BOJ 통계: Accepted 없음]"
 
 
-def _parse_stat_td(soup: BeautifulSoup, unit: str) -> str | None:
+def _parse_stat_td(soup: "BeautifulSoup", unit: str) -> str | None:
     """BeautifulSoup에서 특정 단위의 td 값을 추출한다.
 
     Args:

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -108,7 +108,7 @@ class TestFetchBojStats:
         mock_resp = MagicMock()
         mock_resp.text = html
 
-        with patch("src.core.commit.requests.get", return_value=mock_resp):
+        with patch("requests.get", return_value=mock_resp):
             result = fetch_boj_stats("1000", "session123", "testuser")
 
         assert result == "[✓ 56ms 1234KB]"
@@ -130,7 +130,7 @@ class TestFetchBojStats:
         import requests
 
         with patch(
-            "src.core.commit.requests.get",
+            "requests.get",
             side_effect=requests.exceptions.Timeout("timeout"),
         ):
             result = fetch_boj_stats("1000", "session123", "testuser")
@@ -143,7 +143,7 @@ class TestFetchBojStats:
         mock_resp = MagicMock()
         mock_resp.text = html
 
-        with patch("src.core.commit.requests.get", return_value=mock_resp):
+        with patch("requests.get", return_value=mock_resp):
             result = fetch_boj_stats("1000", "session123", "testuser")
 
         assert "Accepted 없음" in result
@@ -154,7 +154,7 @@ class TestFetchBojStats:
         mock_resp = MagicMock()
         mock_resp.text = html
 
-        with patch("src.core.commit.requests.get", return_value=mock_resp):
+        with patch("requests.get", return_value=mock_resp):
             result = fetch_boj_stats("1000", "session123", "testuser")
 
         assert "파싱 실패" in result
@@ -164,7 +164,7 @@ class TestFetchBojStats:
         mock_resp = MagicMock()
         mock_resp.text = ""
 
-        with patch("src.core.commit.requests.get", return_value=mock_resp):
+        with patch("requests.get", return_value=mock_resp):
             result = fetch_boj_stats("1000", "session123", "testuser")
 
         assert "응답 없음" in result


### PR DESCRIPTION
## Summary
- `src/core/commit.py`에서 `requests`와 `bs4`를 모듈 레벨 import에서 lazy import로 변경
- CI 환경에서 `bs4` 미설치 시 통합 테스트 실패 문제 해결
- 단위 테스트의 mock 패치 경로를 `requests.get`으로 수정

## Test plan
- [x] `python3 -m pytest tests/unit/test_commit.py tests/integration/test_commit_py.py -v` — 27 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>