### PR TITLE
feat(submit): migrate boj submit from Bash to Python [#69]

### DIFF
--- a/src/boj
+++ b/src/boj
@@ -174,12 +174,19 @@ case "$SUBCOMMAND" in
     fi
     ;;
   submit)
-    if [[ ! -x "$CMD_SCRIPT" ]]; then
-      echo "Error: $CMD_SCRIPT 를 찾을 수 없거나 실행할 수 없습니다." >&2
-      echo "  (chmod +x $CMD_SCRIPT 로 실행 권한을 추가해보세요)" >&2
-      exit 1
+    # Python 마이그레이션 (#69): src/cli/boj_submit.py로 라우팅
+    SUBMIT_PY="$ROOT/src/cli/boj_submit.py"
+    if [[ -f "$SUBMIT_PY" ]]; then
+      shift  # subcommand 제거
+      PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" exec python3 "$SUBMIT_PY" "$@"
+    else
+      # fallback: 기존 Bash
+      if [[ ! -x "$CMD_SCRIPT" ]]; then
+        echo "Error: $CMD_SCRIPT 를 찾을 수 없거나 실행할 수 없습니다." >&2
+        exit 1
+      fi
+      exec "$CMD_SCRIPT" "$ROOT" "$PROBLEM_NUM" "${@:3}"
     fi
-    exec "$CMD_SCRIPT" "$ROOT" "$PROBLEM_NUM" "${@:3}"
     ;;
   -h|--help|help|"")
     print_usage

--- a/src/cli/boj_submit.py
+++ b/src/cli/boj_submit.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""boj submit CLI 래퍼 — 인수 파싱 + 출력 포매팅.
+
+Issue #69 — submit.sh Python 마이그레이션.
+
+사용법:
+    python -m src.cli.boj_submit <문제번호> [--lang java|python|cpp|c] [--open] [--force]
+    또는 boj 디스패처에서 호출.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.core.config import BLUE, GREEN, NC, YELLOW, config_get, find_problem_dir
+from src.core.exceptions import BojError
+from src.core.submit import compile_check, generate_submit, open_submit_page
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI 인수를 파싱한다.
+
+    Args:
+        argv: 인수 리스트. None이면 sys.argv[1:] 사용.
+
+    Returns:
+        파싱된 Namespace.
+    """
+    parser = argparse.ArgumentParser(
+        prog="boj submit",
+        description="Submit 파일 생성 (BOJ 제출용)",
+    )
+    parser.add_argument(
+        "problem_id",
+        help="BOJ 문제 번호 (예: 99999)",
+    )
+    parser.add_argument(
+        "--lang",
+        default=None,
+        help="언어 override (java|python|cpp|c). 미지정 시 config 사용.",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        dest="open_browser",
+        help="제출 페이지 브라우저 열기",
+    )
+    parser.add_argument(
+        "--force", "-f",
+        action="store_true",
+        help="기존 Submit 파일 덮어쓰기",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="풀이 루트 디렉터리 override.",
+    )
+    parser.add_argument(
+        "--agent-root",
+        default=None,
+        help="에이전트 루트 디렉터리 override.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """boj submit 메인 진입점.
+
+    Args:
+        argv: CLI 인수. None이면 sys.argv[1:].
+
+    Returns:
+        exit code (0=성공, 1=에러).
+    """
+    args = parse_args(argv)
+
+    # 언어 결정
+    lang = args.lang or config_get("prog_lang", "java")
+
+    # 루트 경로 결정
+    if args.root:
+        solution_root = Path(args.root)
+    else:
+        root_str = config_get("solution_root", "")
+        solution_root = Path(root_str) if root_str else Path.cwd()
+
+    if args.agent_root:
+        agent_root = Path(args.agent_root)
+    else:
+        root_str = config_get("boj_agent_root", "")
+        agent_root = Path(root_str) if root_str else Path.cwd()
+
+    try:
+        # 문제 폴더 찾기
+        problem_dir_str = find_problem_dir(str(solution_root), args.problem_id)
+        if problem_dir_str is None:
+            print(
+                f"Error: '{args.problem_id}'로 시작하는 폴더를 찾을 수 없습니다.",
+                file=sys.stderr,
+            )
+            return 1
+
+        problem_dir = Path(problem_dir_str)
+        problem_name = problem_dir.name
+        template_dir = agent_root / "templates" / lang
+
+        print(f"{BLUE}Submit 생성: {problem_name} ({lang}){NC}")
+
+        # Submit 파일 생성
+        submit_path = generate_submit(
+            problem_dir=problem_dir,
+            lang=lang,
+            template_dir=template_dir,
+            force=args.force,
+        )
+
+        print(f"{GREEN}Submit 생성 완료{NC}")
+
+        # Java 컴파일 검증
+        if lang == "java":
+            print(f"{BLUE}컴파일 검증 중...{NC}")
+            if compile_check(submit_path, template_dir):
+                print(f"{GREEN}컴파일 성공{NC}")
+            else:
+                print(
+                    f"{YELLOW}Warning: Submit.java 컴파일 확인 실패. "
+                    f"수동으로 확인하세요.{NC}",
+                    file=sys.stderr,
+                )
+
+        print()
+        print(f"{BLUE}생성된 파일: {submit_path}{NC}")
+        print()
+
+        # --open: 제출 페이지 브라우저 오픈
+        if args.open_browser:
+            url = f"https://www.acmicpc.net/submit/{args.problem_id}"
+            print(f"{BLUE}제출 페이지 오픈: {url}{NC}")
+            open_submit_page(args.problem_id)
+
+        print()
+        print(f"{GREEN}Submit 완료!{NC}")
+        print()
+        print("다음 단계:")
+        print(f"  1. {submit_path} 내용 확인")
+        print(
+            f"  2. https://www.acmicpc.net/submit/{args.problem_id} "
+            "에서 제출"
+        )
+        print(
+            f"  또는: boj submit {args.problem_id} --open  "
+            "(제출 페이지 자동 오픈)"
+        )
+
+        return 0
+
+    except BojError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    except KeyboardInterrupt:
+        print("\n중단되었습니다.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/submit.py
+++ b/src/core/submit.py
@@ -1,0 +1,450 @@
+"""boj submit 핵심 로직 — Submit 파일 생성.
+
+Issue #69 — submit.sh Python 마이그레이션.
+"""
+
+import platform
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+from src.core.config import config_get, find_problem_dir
+from src.core.exceptions import BojError
+
+
+# ── 지원 언어 및 파일명 매핑 ──
+
+_LANG_EXT: dict[str, str] = {
+    "java": "java",
+    "python": "py",
+    "cpp": "cpp",
+    "c": "c",
+    "kotlin": "kt",
+    "go": "go",
+}
+
+_SUBMIT_LANGS = frozenset(_LANG_EXT.keys())
+
+
+# ── Java Submit 생성 ──
+
+
+def extract_imports(source: str) -> set[str]:
+    """Java 소스에서 import 문을 추출한다.
+
+    Args:
+        source: Java 소스 코드 문자열.
+
+    Returns:
+        import 문 집합 (각 줄 전체, 예: "import java.util.*;").
+    """
+    return {
+        line
+        for line in source.splitlines()
+        if line.startswith("import ")
+    }
+
+
+def strip_class_modifiers(source: str) -> str:
+    """public class → class 변환, import/package 라인 제거.
+
+    Args:
+        source: Java 소스 코드 문자열.
+
+    Returns:
+        변환된 소스 코드.
+    """
+    lines = []
+    for line in source.splitlines():
+        if line.startswith("import ") or line.startswith("package "):
+            continue
+        line = re.sub(r"^public class Solution", "class Solution", line)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def strip_parse_decorators(source: str) -> str:
+    """Parse 클래스에서 implements ParseAndCallSolve, @Override 제거.
+
+    public class Parse → class Parse 변환도 수행한다.
+    import/package 라인도 제거한다.
+
+    Args:
+        source: Parse.java 소스 코드 문자열.
+
+    Returns:
+        변환된 소스 코드.
+    """
+    lines = []
+    for line in source.splitlines():
+        if line.startswith("import ") or line.startswith("package "):
+            continue
+        if re.match(r"^\s*@Override\s*$", line):
+            continue
+        line = re.sub(r"^public class Parse", "class Parse", line)
+        line = re.sub(r"\s+implements\s+ParseAndCallSolve", "", line)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def generate_java_submit(
+    solution_path: Path,
+    parse_path: Path | None,
+    template_dir: Path,
+) -> str:
+    """Java Submit 파일 내용을 생성한다.
+
+    1. Solution + Parse의 import를 합산하고 중복 제거
+    2. public class Main { main() } 생성
+    3. Parse 있으면 parseAndCallSolve 호출, 없으면 TODO 스텁
+    4. Solution: public class → class, import/package 제거
+    5. Parse: implements/Override 제거, import/package 제거
+
+    Args:
+        solution_path: Solution.java 파일 경로.
+        parse_path: Parse.java 파일 경로. None이면 Parse 없는 모드.
+        template_dir: 템플릿 디렉터리 경로 (컴파일 검증 시 사용).
+
+    Returns:
+        생성된 Submit.java 파일 내용 문자열.
+    """
+    solution_src = solution_path.read_text(encoding="utf-8")
+
+    # import 합산 (기본 import + Solution + Parse)
+    imports: set[str] = {"import java.util.*;", "import java.io.*;"}
+    imports |= extract_imports(solution_src)
+
+    has_parse = parse_path is not None and parse_path.exists()
+    parse_src = ""
+    if has_parse:
+        parse_src = parse_path.read_text(encoding="utf-8")
+        imports |= extract_imports(parse_src)
+
+    # import 정렬
+    sorted_imports = sorted(imports)
+
+    # Main 클래스 본문
+    if has_parse:
+        main_body = (
+            "        Parse parser = new Parse();\n"
+            "        String result = parser.parseAndCallSolve(sol, input);\n"
+            "        System.out.println(result);\n"
+            "    }\n"
+            "}"
+        )
+    else:
+        main_body = (
+            "        // TODO: 입력 파싱 후 sol.solve(...) 호출\n"
+            "        // StringTokenizer st = new StringTokenizer(input);\n"
+            "        // int n = Integer.parseInt(st.nextToken());\n"
+            "        // System.out.println(sol.solve(n));\n"
+            "    }\n"
+            "}"
+        )
+
+    main_class = (
+        "public class Main {\n"
+        "    public static void main(String[] args) throws Exception {\n"
+        "        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));\n"
+        "        StringBuilder sb = new StringBuilder();\n"
+        "        String line;\n"
+        "        while ((line = br.readLine()) != null) {\n"
+        "            sb.append(line).append('\\n');\n"
+        "        }\n"
+        "        String input = sb.toString().trim();\n"
+        "        Solution sol = new Solution();\n"
+        + main_body
+    )
+
+    # Solution 클래스 변환
+    solution_block = strip_class_modifiers(solution_src)
+
+    # 최종 결합
+    parts = ["\n".join(sorted_imports), ""]
+    parts.append("")
+    parts.append(main_class)
+    parts.append("")
+    parts.append("// ===== Solution =====")
+    parts.append(solution_block)
+
+    if has_parse:
+        parse_block = strip_parse_decorators(parse_src)
+        parts.append("")
+        parts.append("// ===== Parse =====")
+        parts.append(parse_block)
+
+    return "\n".join(parts) + "\n"
+
+
+# ── Python Submit 생성 ──
+
+
+def generate_python_submit(solution_path: Path) -> str:
+    """Python Submit 파일 내용을 생성한다.
+
+    #!/usr/bin/env python3 + import sys + solution 내용 + __main__ block.
+
+    Args:
+        solution_path: solution.py 파일 경로.
+
+    Returns:
+        생성된 Submit.py 파일 내용 문자열.
+    """
+    solution_src = solution_path.read_text(encoding="utf-8")
+
+    parts = [
+        "#!/usr/bin/env python3",
+        "import sys",
+        "input = sys.stdin.readline",
+        "",
+        solution_src,
+        "",
+        "",
+        'if __name__ == "__main__":',
+        "    data = sys.stdin.read().strip()",
+        "    sol = Solution()",
+        "    # Parse가 있으면 from test.parse import parse_and_solve 활용 가능",
+        "    # result = parse_and_solve(sol, data)",
+        "    # print(result)",
+        "",
+    ]
+    return "\n".join(parts)
+
+
+# ── C/C++ Submit 생성 ──
+
+
+def generate_cpp_submit(solution_path: Path) -> str:
+    """C++ Submit 파일을 생성한다.
+
+    bits/stdc++.h + solution (기존 #include 제거) + main() TODO.
+
+    Args:
+        solution_path: Solution.cpp 파일 경로.
+
+    Returns:
+        생성된 Submit.cpp 파일 내용 문자열.
+    """
+    solution_src = solution_path.read_text(encoding="utf-8")
+
+    # 기존 #include 제거
+    filtered = [
+        line for line in solution_src.splitlines()
+        if not line.startswith("#include")
+    ]
+
+    parts = [
+        "#include <bits/stdc++.h>",
+        "using namespace std;",
+        "",
+        "\n".join(filtered),
+        "",
+        "int main() {",
+        "    ios_base::sync_with_stdio(false);",
+        "    cin.tie(NULL);",
+        "    // TODO: 입력 파싱 후 solve() 호출",
+        "    return 0;",
+        "}",
+        "",
+    ]
+    return "\n".join(parts)
+
+
+def generate_c_submit(solution_path: Path) -> str:
+    """C Submit 파일을 생성한다.
+
+    stdio/stdlib/string.h + solution (기존 #include 제거) + main() TODO.
+
+    Args:
+        solution_path: Solution.c 파일 경로.
+
+    Returns:
+        생성된 Submit.c 파일 내용 문자열.
+    """
+    solution_src = solution_path.read_text(encoding="utf-8")
+
+    # 기존 #include 제거
+    filtered = [
+        line for line in solution_src.splitlines()
+        if not line.startswith("#include")
+    ]
+
+    parts = [
+        "#include <stdio.h>",
+        "#include <stdlib.h>",
+        "#include <string.h>",
+        "",
+        "\n".join(filtered),
+        "",
+        "int main() {",
+        "    // TODO: 입력 파싱 후 solve() 호출",
+        "    return 0;",
+        "}",
+        "",
+    ]
+    return "\n".join(parts)
+
+
+# ── 공통 ──
+
+
+def _find_solution_file(problem_dir: Path, lang: str) -> Path | None:
+    """언어별 Solution 파일을 찾는다.
+
+    Python은 solution.py 우선, Solution.py 차선.
+
+    Args:
+        problem_dir: 문제 폴더 경로.
+        lang: 프로그래밍 언어.
+
+    Returns:
+        Solution 파일 경로. 없으면 None.
+    """
+    ext = _LANG_EXT[lang]
+
+    if lang == "python":
+        # solution.py 우선 (run.sh와 동일)
+        lower = problem_dir / "solution.py"
+        upper = problem_dir / "Solution.py"
+        if lower.exists():
+            return lower
+        if upper.exists():
+            return upper
+        return None
+
+    sol = problem_dir / f"Solution.{ext}"
+    return sol if sol.exists() else None
+
+
+def generate_submit(
+    problem_dir: Path,
+    lang: str,
+    template_dir: Path,
+    force: bool = False,
+) -> Path:
+    """Submit 파일 생성 통합 함수.
+
+    Args:
+        problem_dir: 문제 폴더 경로.
+        lang: 프로그래밍 언어.
+        template_dir: 템플릿 디렉터리 경로.
+        force: True면 기존 Submit 파일 덮어쓰기.
+
+    Returns:
+        생성된 submit 파일 경로.
+
+    Raises:
+        BojError: Solution 파일 없음, 미지원 언어, 기존 파일 존재(force=False).
+    """
+    if lang not in _SUBMIT_LANGS:
+        raise BojError(
+            f"'submit' 명령은 현재 {'/'.join(sorted(_SUBMIT_LANGS))}만 "
+            f"지원합니다."
+        )
+
+    # 1. Solution 파일 확인
+    solution_path = _find_solution_file(problem_dir, lang)
+    if solution_path is None:
+        ext = _LANG_EXT[lang]
+        if lang == "python":
+            raise BojError(
+                f"Solution 파일이 없습니다 (solution.py 또는 Solution.{ext}). "
+                "먼저 풀이를 작성하세요."
+            )
+        raise BojError(
+            f"Solution 파일이 없습니다 (Solution.{ext}). "
+            "먼저 풀이를 작성하세요."
+        )
+
+    # 2. submit/ 디렉터리 생성
+    submit_dir = problem_dir / "submit"
+    submit_dir.mkdir(parents=True, exist_ok=True)
+
+    # 3. Submit 파일 경로 결정
+    ext = _LANG_EXT[lang]
+    submit_path = submit_dir / f"Submit.{ext}"
+
+    # 4. 기존 파일 존재 + not force → BojError
+    if submit_path.exists() and not force:
+        raise BojError(
+            f"submit/Submit.{ext} 이 이미 있습니다. "
+            "덮어쓰려면 --force 옵션을 사용하세요."
+        )
+
+    # 5. 언어별 생성 함수 호출
+    if lang == "java":
+        parse_path = problem_dir / "test" / "Parse.java"
+        if not parse_path.exists():
+            parse_path = None
+        content = generate_java_submit(solution_path, parse_path, template_dir)
+    elif lang == "python":
+        content = generate_python_submit(solution_path)
+    elif lang == "cpp":
+        content = generate_cpp_submit(solution_path)
+    elif lang == "c":
+        content = generate_c_submit(solution_path)
+    else:
+        # kotlin, go — 에이전트 활용 안내 (submit.sh와 동일)
+        raise BojError(
+            f"{lang} Submit 생성은 에이전트를 통해 진행하세요."
+        )
+
+    # 6. submit 파일 쓰기
+    submit_path.write_text(content, encoding="utf-8")
+
+    return submit_path
+
+
+def compile_check(submit_path: Path, template_dir: Path) -> bool:
+    """Java Submit 파일의 컴파일을 검증한다.
+
+    실패해도 Warning만 출력하고 False를 반환한다 (non-fatal).
+
+    Args:
+        submit_path: Submit.java 파일 경로.
+        template_dir: 템플릿 디렉터리 (사용하지 않지만 인터페이스 일관성).
+
+    Returns:
+        True면 컴파일 성공, False면 실패.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        main_java = tmp / "Main.java"
+        main_java.write_text(
+            submit_path.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["javac", str(main_java)],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+
+
+def open_submit_page(problem_id: str) -> None:
+    """브라우저에서 BOJ 제출 페이지를 연다.
+
+    플랫폼에 따라 open(macOS) 또는 xdg-open(Linux)을 사용한다.
+
+    Args:
+        problem_id: BOJ 문제 번호.
+    """
+    url = f"https://www.acmicpc.net/submit/{problem_id}"
+
+    system = platform.system()
+    if system == "Darwin":
+        cmd = "open"
+    elif system == "Linux":
+        cmd = "xdg-open"
+    else:
+        # Windows 또는 기타 — 경고만 출력
+        return
+
+    subprocess.Popen(
+        [cmd, url],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )

--- a/tests/integration/test_submit_py.py
+++ b/tests/integration/test_submit_py.py
@@ -1,0 +1,192 @@
+"""boj submit 통합 테스트 — CLI 경유 전체 흐름.
+
+Issue #69 — submit.sh Python 마이그레이션.
+fixture 99999를 사용하여 전체 파이프라인을 검증한다.
+"""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import FIXTURES_DIR, run_boj, setup_problem_dir
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+
+def _setup_java_problem(tmp_path):
+    """Java 픽스처 기반 문제 폴더를 구성한다."""
+    fix = FIXTURES_DIR / "99999"
+    return setup_problem_dir(tmp_path, fix, lang="java")
+
+
+def _setup_python_problem(tmp_path):
+    """Python 픽스처 기반 문제 폴더를 구성한다."""
+    fix = FIXTURES_DIR / "99999"
+    return setup_problem_dir(tmp_path, fix, lang="python")
+
+
+# ---------------------------------------------------------------------------
+# CLI 통합 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitPyIntegration:
+    """CLI 경유 submit 통합 테스트."""
+
+    def test_java_submit_generates_file(self, boj_env):
+        """Java submit 파일이 생성된다."""
+        tmp_path, env = boj_env
+        fix = FIXTURES_DIR / "99999"
+        prob_dir = _setup_java_problem(tmp_path)
+
+        result = run_boj(env, "submit", "99999", "--lang", "java")
+
+        assert result.returncode == 0, (
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+        submit_file = prob_dir / "submit" / "Submit.java"
+        assert submit_file.exists()
+
+        content = submit_file.read_text()
+        assert "public class Main" in content
+        assert "class Solution" in content
+
+    def test_python_submit_generates_file(self, boj_env):
+        """Python submit 파일이 생성된다."""
+        tmp_path, env = boj_env
+        fix = FIXTURES_DIR / "99999"
+        prob_dir = _setup_python_problem(tmp_path)
+
+        result = run_boj(env, "submit", "99999", "--lang", "python")
+
+        assert result.returncode == 0, (
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+        submit_file = prob_dir / "submit" / "Submit.py"
+        assert submit_file.exists()
+
+        content = submit_file.read_text()
+        assert "#!/usr/bin/env python3" in content
+        assert "class Solution:" in content
+
+    def test_missing_solution_returns_error(self, boj_env):
+        """Solution 없으면 에러."""
+        tmp_path, env = boj_env
+
+        # 빈 문제 폴더 생성
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        result = run_boj(env, "submit", "99999", "--lang", "java")
+
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+    def test_missing_problem_dir_returns_error(self, boj_env):
+        """SB1: 문제 폴더 없으면 에러."""
+        _tmp_path, env = boj_env
+
+        result = run_boj(env, "submit", "99999", "--lang", "java")
+
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+    def test_force_flag_overwrites(self, boj_env):
+        """--force로 기존 파일 덮어쓰기."""
+        tmp_path, env = boj_env
+        prob_dir = _setup_java_problem(tmp_path)
+
+        # 첫 번째 생성
+        result1 = run_boj(env, "submit", "99999", "--lang", "java")
+        assert result1.returncode == 0
+
+        # 두 번째 생성 (force 없이) → 에러
+        result2 = run_boj(env, "submit", "99999", "--lang", "java")
+        assert result2.returncode == 1
+
+        # --force로 덮어쓰기
+        result3 = run_boj(
+            env, "submit", "99999", "--lang", "java", "--force",
+        )
+        assert result3.returncode == 0
+
+    def test_open_flag_accepted(self, boj_env):
+        """SB10: --open 플래그가 CLI에서 허용된다 (core 레벨에서 mock)."""
+        from src.core.submit import open_submit_page
+
+        with patch("src.core.submit.subprocess.Popen") as mock_popen:
+            open_submit_page("99999")
+
+        mock_popen.assert_called_once()
+        call_args = mock_popen.call_args[0][0]
+        assert "99999" in call_args[1]
+        assert "acmicpc.net" in call_args[1]
+
+
+# ---------------------------------------------------------------------------
+# core 레벨 통합 테스트 (CLI 거치지 않음)
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitCoreIntegration:
+    """core 함수 직접 호출 통합 테스트."""
+
+    def test_java_with_parse_fixture(self, tmp_path):
+        """실제 fixture로 Java submit 생성 (Parse 포함)."""
+        from src.core.submit import generate_submit
+
+        fix = FIXTURES_DIR / "99999"
+        prob_dir = setup_problem_dir(tmp_path, fix, lang="java")
+        template_dir = tmp_path / "templates" / "java"
+
+        submit_path = generate_submit(prob_dir, "java", template_dir)
+
+        content = submit_path.read_text()
+        assert "public class Main" in content
+        assert "class Solution" in content
+        assert "class Parse" in content
+        assert "parser.parseAndCallSolve" in content
+
+    def test_java_without_parse(self, tmp_path):
+        """SB3: Parse 없을 때 TODO 스텁."""
+        from src.core.submit import generate_submit
+
+        prob_dir = tmp_path / "99999-test"
+        prob_dir.mkdir()
+
+        sol = prob_dir / "Solution.java"
+        sol.write_text(
+            "public class Solution {\n"
+            "    public int solve(int n) { return n; }\n"
+            "}\n"
+        )
+
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        submit_path = generate_submit(prob_dir, "java", template_dir)
+
+        content = submit_path.read_text()
+        assert "// TODO:" in content
+        assert "Parse" not in content.split("// ===== Solution =====")[1]
+
+    def test_python_with_fixture(self, tmp_path):
+        """실제 fixture로 Python submit 생성."""
+        from src.core.submit import generate_submit
+
+        fix = FIXTURES_DIR / "99999"
+        prob_dir = setup_problem_dir(tmp_path, fix, lang="python")
+        template_dir = tmp_path / "templates" / "python"
+
+        submit_path = generate_submit(prob_dir, "python", template_dir)
+
+        content = submit_path.read_text()
+        assert "#!/usr/bin/env python3" in content
+        assert "class Solution:" in content

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -1,0 +1,668 @@
+"""src/core/submit.py 단위 테스트.
+
+Issue #69 — boj submit Python 마이그레이션.
+edge-cases SB1-SB10 커버리지.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.core.exceptions import BojError
+from src.core.submit import (
+    compile_check,
+    extract_imports,
+    generate_c_submit,
+    generate_cpp_submit,
+    generate_java_submit,
+    generate_python_submit,
+    generate_submit,
+    strip_class_modifiers,
+    strip_parse_decorators,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_imports
+# ---------------------------------------------------------------------------
+
+
+class TestExtractImports:
+    """Java 소스에서 import 문을 추출한다."""
+
+    def test_extract_basic_imports(self):
+        """기본 import 추출."""
+        source = (
+            "import java.util.*;\n"
+            "\n"
+            "public class Solution {\n"
+            "    public int solve(int a) { return a; }\n"
+            "}\n"
+        )
+        result = extract_imports(source)
+        assert result == {"import java.util.*;"}
+
+    def test_extract_multiple_imports(self):
+        """여러 import 추출."""
+        source = (
+            "import java.util.*;\n"
+            "import java.io.*;\n"
+            "import java.math.BigInteger;\n"
+            "\n"
+            "public class Solution {}\n"
+        )
+        result = extract_imports(source)
+        assert result == {
+            "import java.util.*;",
+            "import java.io.*;",
+            "import java.math.BigInteger;",
+        }
+
+    def test_extract_no_imports(self):
+        """import 없는 소스."""
+        source = "public class Solution {}\n"
+        result = extract_imports(source)
+        assert result == set()
+
+    def test_extract_duplicates_returns_set(self):
+        """중복 import는 set으로 제거."""
+        source = (
+            "import java.util.*;\n"
+            "import java.util.*;\n"
+            "public class Solution {}\n"
+        )
+        result = extract_imports(source)
+        assert result == {"import java.util.*;"}
+
+
+# ---------------------------------------------------------------------------
+# strip_class_modifiers
+# ---------------------------------------------------------------------------
+
+
+class TestStripClassModifiers:
+    """public class -> class 변환, import/package 제거."""
+
+    def test_public_class_to_class(self):
+        """public class Solution -> class Solution."""
+        source = (
+            "import java.util.*;\n"
+            "package com.example;\n"
+            "\n"
+            "public class Solution {\n"
+            "    public int solve(int a) { return a; }\n"
+            "}\n"
+        )
+        result = strip_class_modifiers(source)
+        assert "class Solution {" in result
+        assert "public class Solution" not in result
+
+    def test_removes_import_lines(self):
+        """import 라인 제거."""
+        source = (
+            "import java.util.*;\n"
+            "public class Solution {}\n"
+        )
+        result = strip_class_modifiers(source)
+        assert "import" not in result
+
+    def test_removes_package_lines(self):
+        """package 라인 제거."""
+        source = (
+            "package com.example;\n"
+            "public class Solution {}\n"
+        )
+        result = strip_class_modifiers(source)
+        assert "package" not in result
+
+    def test_preserves_inner_class(self):
+        """SB6: inner class는 보존."""
+        source = (
+            "public class Solution {\n"
+            "    static class Node {\n"
+            "        int val;\n"
+            "    }\n"
+            "    public int solve(int a) { return a; }\n"
+            "}\n"
+        )
+        result = strip_class_modifiers(source)
+        assert "static class Node" in result
+        assert "int val;" in result
+
+
+# ---------------------------------------------------------------------------
+# strip_parse_decorators
+# ---------------------------------------------------------------------------
+
+
+class TestStripParseDecorators:
+    """Parse implements ParseAndCallSolve, @Override 제거."""
+
+    def test_removes_implements(self):
+        """implements ParseAndCallSolve 제거."""
+        source = (
+            "import java.util.*;\n"
+            "\n"
+            "public class Parse implements ParseAndCallSolve {\n"
+            "    @Override\n"
+            "    public String parseAndCallSolve(Solution sol, String input) {\n"
+            "        return \"\";\n"
+            "    }\n"
+            "}\n"
+        )
+        result = strip_parse_decorators(source)
+        assert "implements ParseAndCallSolve" not in result
+        assert "class Parse {" in result
+
+    def test_removes_override(self):
+        """@Override 제거."""
+        source = (
+            "public class Parse implements ParseAndCallSolve {\n"
+            "    @Override\n"
+            "    public String parseAndCallSolve(Solution sol, String input) {\n"
+            "        return \"\";\n"
+            "    }\n"
+            "}\n"
+        )
+        result = strip_parse_decorators(source)
+        assert "@Override" not in result
+
+    def test_public_class_to_class(self):
+        """public class Parse -> class Parse."""
+        source = "public class Parse implements ParseAndCallSolve {}\n"
+        result = strip_parse_decorators(source)
+        assert "class Parse {" in result
+        assert "public class Parse" not in result
+
+    def test_removes_import_and_package(self):
+        """import/package 라인 제거."""
+        source = (
+            "import java.util.*;\n"
+            "package test;\n"
+            "public class Parse {}\n"
+        )
+        result = strip_parse_decorators(source)
+        assert "import" not in result
+        assert "package" not in result
+
+
+# ---------------------------------------------------------------------------
+# generate_java_submit
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateJavaSubmit:
+    """Java Submit 파일 생성."""
+
+    def test_with_parse(self, tmp_path):
+        """Parse 있을 때 parseAndCallSolve 호출 포함."""
+        sol = tmp_path / "Solution.java"
+        sol.write_text(
+            "import java.util.*;\n"
+            "\n"
+            "public class Solution {\n"
+            "    public int solve(int a, int b) {\n"
+            "        return a + b;\n"
+            "    }\n"
+            "}\n"
+        )
+        parse = tmp_path / "Parse.java"
+        parse.write_text(
+            "import java.util.*;\n"
+            "\n"
+            "public class Parse implements ParseAndCallSolve {\n"
+            "    @Override\n"
+            "    public String parseAndCallSolve("
+            "Solution sol, String input) {\n"
+            "        return \"\";\n"
+            "    }\n"
+            "}\n"
+        )
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_java_submit(sol, parse, template_dir)
+
+        assert "public class Main {" in result
+        assert "class Solution {" in result
+        assert "class Parse {" in result
+        assert "parser.parseAndCallSolve(sol, input)" in result
+        assert "import java.util.*;" in result
+        assert "import java.io.*;" in result
+        # import/package 제거 확인 (Solution/Parse 블록 내)
+        assert "// ===== Solution =====" in result
+        assert "// ===== Parse =====" in result
+        # @Override, implements 제거 확인
+        assert "@Override" not in result
+        assert "implements ParseAndCallSolve" not in result
+
+    def test_without_parse(self, tmp_path):
+        """Parse 없을 때 TODO 스텁 포함."""
+        sol = tmp_path / "Solution.java"
+        sol.write_text(
+            "public class Solution {\n"
+            "    public int solve(int n) {\n"
+            "        return n;\n"
+            "    }\n"
+            "}\n"
+        )
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_java_submit(sol, None, template_dir)
+
+        assert "public class Main {" in result
+        assert "class Solution {" in result
+        assert "// TODO:" in result
+        assert "Parse" not in result.split("// ===== Solution =====")[1]
+
+    def test_with_fixture(self, tmp_path):
+        """실제 fixture 파일로 생성."""
+        fixtures = Path(__file__).resolve().parent.parent / "fixtures" / "99999"
+        sol = fixtures / "Solution.java"
+        parse = fixtures / "test" / "Parse.java"
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_java_submit(sol, parse, template_dir)
+
+        assert "public class Main {" in result
+        assert "class Solution {" in result
+        assert "class Parse {" in result
+        assert "parser.parseAndCallSolve" in result
+
+    def test_inner_classes_preserved(self, tmp_path):
+        """SB6: inner class가 있는 Solution."""
+        sol = tmp_path / "Solution.java"
+        sol.write_text(
+            "import java.util.*;\n"
+            "\n"
+            "public class Solution {\n"
+            "    static class Node {\n"
+            "        int val;\n"
+            "        Node next;\n"
+            "    }\n"
+            "    public int solve(int a) { return a; }\n"
+            "}\n"
+        )
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_java_submit(sol, None, template_dir)
+
+        assert "static class Node" in result
+        assert "int val;" in result
+
+    def test_duplicate_imports_deduplicated(self, tmp_path):
+        """Solution과 Parse의 중복 import 제거."""
+        sol = tmp_path / "Solution.java"
+        sol.write_text(
+            "import java.util.*;\n"
+            "import java.io.*;\n"
+            "\n"
+            "public class Solution {}\n"
+        )
+        parse = tmp_path / "Parse.java"
+        parse.write_text(
+            "import java.util.*;\n"
+            "import java.io.*;\n"
+            "\n"
+            "public class Parse implements ParseAndCallSolve {}\n"
+        )
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_java_submit(sol, parse, template_dir)
+
+        # 중복 없이 각 import 한 번만
+        assert result.count("import java.util.*;") == 1
+        assert result.count("import java.io.*;") == 1
+
+
+# ---------------------------------------------------------------------------
+# generate_python_submit
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePythonSubmit:
+    """Python Submit 파일 생성."""
+
+    def test_basic_generation(self, tmp_path):
+        """기본 Python submit 생성."""
+        sol = tmp_path / "solution.py"
+        sol.write_text(
+            "class Solution:\n"
+            "    def solve(self, a: int, b: int) -> int:\n"
+            "        return a + b\n"
+        )
+
+        result = generate_python_submit(sol)
+
+        assert "#!/usr/bin/env python3" in result
+        assert "import sys" in result
+        assert "input = sys.stdin.readline" in result
+        assert "class Solution:" in result
+        assert 'if __name__ == "__main__":' in result
+
+    def test_with_fixture(self):
+        """실제 fixture 파일로 생성."""
+        fixtures = Path(__file__).resolve().parent.parent / "fixtures" / "99999"
+        sol = fixtures / "solution.py"
+
+        result = generate_python_submit(sol)
+
+        assert "class Solution:" in result
+        assert "def solve" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_cpp_submit
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateCppSubmit:
+    """C++ Submit 파일 생성."""
+
+    def test_removes_existing_includes(self, tmp_path):
+        """기존 #include 제거."""
+        sol = tmp_path / "Solution.cpp"
+        sol.write_text(
+            "#include <iostream>\n"
+            "#include <vector>\n"
+            "\n"
+            "class Solution {\n"
+            "public:\n"
+            "    int solve(int n) { return n; }\n"
+            "};\n"
+        )
+
+        result = generate_cpp_submit(sol)
+
+        assert "#include <bits/stdc++.h>" in result
+        assert "using namespace std;" in result
+        assert "#include <iostream>" not in result
+        assert "#include <vector>" not in result
+        assert "class Solution" in result
+        assert "int main()" in result
+
+    def test_preserves_non_include_code(self, tmp_path):
+        """#include 아닌 코드는 보존."""
+        sol = tmp_path / "Solution.cpp"
+        sol.write_text(
+            "#include <vector>\n"
+            "\n"
+            "int custom_func() { return 42; }\n"
+        )
+
+        result = generate_cpp_submit(sol)
+
+        assert "int custom_func()" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_c_submit
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateCSubmit:
+    """C Submit 파일 생성."""
+
+    def test_basic_generation(self, tmp_path):
+        """기본 C submit 생성."""
+        sol = tmp_path / "Solution.c"
+        sol.write_text(
+            "#include <math.h>\n"
+            "\n"
+            "int solve(int n) { return n; }\n"
+        )
+
+        result = generate_c_submit(sol)
+
+        assert "#include <stdio.h>" in result
+        assert "#include <stdlib.h>" in result
+        assert "#include <string.h>" in result
+        assert "#include <math.h>" not in result
+        assert "int solve(int n)" in result
+        assert "int main()" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_submit (통합)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSubmit:
+    """Submit 파일 생성 통합 함수."""
+
+    def test_missing_solution_raises_error(self, tmp_path):
+        """SB2: Solution 없으면 BojError."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        with pytest.raises(BojError, match="Solution 파일이 없습니다"):
+            generate_submit(problem_dir, "java", template_dir)
+
+    def test_existing_submit_no_force_raises_error(self, tmp_path):
+        """SB5: 기존 Submit + force=False → BojError."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        # Solution 생성
+        sol = problem_dir / "Solution.java"
+        sol.write_text("public class Solution {}\n")
+
+        # 기존 Submit 파일
+        submit_dir = problem_dir / "submit"
+        submit_dir.mkdir()
+        (submit_dir / "Submit.java").write_text("existing\n")
+
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        with pytest.raises(BojError, match="이미 있습니다"):
+            generate_submit(problem_dir, "java", template_dir, force=False)
+
+    def test_existing_submit_with_force_overwrites(self, tmp_path):
+        """SB5: force=True면 덮어쓰기."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        sol = problem_dir / "Solution.java"
+        sol.write_text("public class Solution {}\n")
+
+        submit_dir = problem_dir / "submit"
+        submit_dir.mkdir()
+        (submit_dir / "Submit.java").write_text("old content\n")
+
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(
+            problem_dir, "java", template_dir, force=True,
+        )
+
+        assert result.exists()
+        assert result.read_text() != "old content\n"
+
+    def test_creates_submit_directory(self, tmp_path):
+        """SB4: submit/ 폴더 자동 생성."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        sol = problem_dir / "Solution.java"
+        sol.write_text("public class Solution {}\n")
+
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(problem_dir, "java", template_dir)
+
+        assert result.parent.name == "submit"
+        assert result.parent.exists()
+
+    def test_unsupported_language_raises_error(self, tmp_path):
+        """미지원 언어 BojError."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+        template_dir = tmp_path / "templates" / "rust"
+        template_dir.mkdir(parents=True)
+
+        with pytest.raises(BojError, match="지원합니다"):
+            generate_submit(problem_dir, "rust", template_dir)
+
+    def test_java_submit_end_to_end(self, tmp_path):
+        """Java submit 전체 흐름."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        sol = problem_dir / "Solution.java"
+        sol.write_text(
+            "import java.util.*;\n"
+            "\n"
+            "public class Solution {\n"
+            "    public int solve(int a, int b) {\n"
+            "        return a + b;\n"
+            "    }\n"
+            "}\n"
+        )
+
+        test_dir = problem_dir / "test"
+        test_dir.mkdir()
+        parse = test_dir / "Parse.java"
+        parse.write_text(
+            "import java.util.*;\n"
+            "\n"
+            "public class Parse implements ParseAndCallSolve {\n"
+            "    @Override\n"
+            "    public String parseAndCallSolve("
+            "Solution sol, String input) {\n"
+            "        return \"\";\n"
+            "    }\n"
+            "}\n"
+        )
+
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(problem_dir, "java", template_dir)
+
+        assert result.name == "Submit.java"
+        content = result.read_text()
+        assert "public class Main" in content
+        assert "class Solution" in content
+
+    def test_python_submit_end_to_end(self, tmp_path):
+        """Python submit 전체 흐름."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        sol = problem_dir / "solution.py"
+        sol.write_text(
+            "class Solution:\n"
+            "    def solve(self, a: int, b: int) -> int:\n"
+            "        return a + b\n"
+        )
+
+        template_dir = tmp_path / "templates" / "python"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(problem_dir, "python", template_dir)
+
+        assert result.name == "Submit.py"
+        content = result.read_text()
+        assert "#!/usr/bin/env python3" in content
+        assert "class Solution:" in content
+
+    def test_python_solution_py_found(self, tmp_path):
+        """Python은 solution.py 파일을 찾는다."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        (problem_dir / "solution.py").write_text(
+            "class Solution:\n    def solve(self): pass\n"
+        )
+
+        template_dir = tmp_path / "templates" / "python"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(problem_dir, "python", template_dir)
+        content = result.read_text()
+
+        assert "class Solution:" in content
+        assert "def solve" in content
+
+    def test_cpp_submit_end_to_end(self, tmp_path):
+        """C++ submit 전체 흐름."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        sol = problem_dir / "Solution.cpp"
+        sol.write_text(
+            "#include <iostream>\n"
+            "\n"
+            "class Solution {\n"
+            "public:\n"
+            "    int solve(int n) { return n; }\n"
+            "};\n"
+        )
+
+        template_dir = tmp_path / "templates" / "cpp"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(problem_dir, "cpp", template_dir)
+
+        assert result.name == "Submit.cpp"
+
+    def test_c_submit_end_to_end(self, tmp_path):
+        """C submit 전체 흐름."""
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        sol = problem_dir / "Solution.c"
+        sol.write_text("int solve(int n) { return n; }\n")
+
+        template_dir = tmp_path / "templates" / "c"
+        template_dir.mkdir(parents=True)
+
+        result = generate_submit(problem_dir, "c", template_dir)
+
+        assert result.name == "Submit.c"
+
+
+# ---------------------------------------------------------------------------
+# compile_check
+# ---------------------------------------------------------------------------
+
+
+class TestCompileCheck:
+    """Java 컴파일 검증."""
+
+    def test_compile_success(self, tmp_path):
+        """SB9: 컴파일 성공."""
+        submit = tmp_path / "Submit.java"
+        submit.write_text(
+            "import java.io.*;\n"
+            "import java.util.*;\n"
+            "\n"
+            "public class Main {\n"
+            "    public static void main(String[] args) {\n"
+            "        System.out.println(\"hello\");\n"
+            "    }\n"
+            "}\n"
+        )
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        assert compile_check(submit, template_dir) is True
+
+    def test_compile_failure(self, tmp_path):
+        """SB9: 컴파일 실패 시 False (non-fatal)."""
+        submit = tmp_path / "Submit.java"
+        submit.write_text("this is not valid java code\n")
+        template_dir = tmp_path / "templates" / "java"
+        template_dir.mkdir(parents=True)
+
+        assert compile_check(submit, template_dir) is False


### PR DESCRIPTION
## Summary
- `boj submit` 명령어를 Bash(`src/commands/submit.sh`)에서 Python(`src/core/submit.py` + `src/cli/boj_submit.py`)으로 마이그레이션
- 디스패처(`src/boj`)에 Python 라우팅 추가 (Bash fallback 유지)
- Java/Python/C++/C 언어 submit 생성 지원
- 단위 테스트 + 통합 테스트 추가

## Changes
- `src/core/submit.py`: 순수 로직 (extract_imports, strip_class_modifiers, generate_java_submit, generate_python_submit, generate_submit, compile_check)
- `src/cli/boj_submit.py`: CLI 래퍼 (argparse)
- `tests/unit/test_submit.py`: 단위 테스트 (34개)
- `tests/integration/test_submit_py.py`: 통합 테스트 (9개)
- `src/boj`: submit 케이스 Python 라우팅 추가 — 이제 모든 명령어(make, run, open, review, commit, submit)가 Python 라우팅 완료

## Test plan
- [x] `python3 -m pytest tests/ -v` — 449 passed, 1 skipped, 0 failures
- [ ] `BOJ_ROOT=. src/boj submit 99999` — 수동 확인

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>