### PR TITLE
feat(skill): /start 시 git worktree 자동 생성 [#89]

### DIFF
--- a/.claude/skills/done/SKILL.md
+++ b/.claude/skills/done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: done
-description: 이슈 완료 원스텝: verify(7단계) → 미커밋 처리 → push → PR 생성 → 이슈 라벨 업데이트
+description: 이슈 완료 원스텝: verify(7단계) → 미커밋 처리 → push → PR 생성 → 이슈 라벨 업데이트 → worktree 정리
 tools:
   - Bash
   - Read
@@ -86,10 +86,33 @@ gh pr create \
 ```bash
 gh issue edit $ISSUE_NUM \
   --remove-label "in-progress" \
-  --add-label "review"
+  --add-label "review" 2>/dev/null || true
 ```
 
-## 7. 완료 요약
+## 7. Worktree 정리 안내
+
+현재 worktree에서 작업 중인지 확인:
+```bash
+git worktree list | grep "$(pwd)"
+```
+
+worktree 내에서 작업 중이면 정리 안내:
+```
+현재 worktree에서 작업 중입니다: [worktree 경로]
+PR이 머지된 후 다음 명령어로 정리할 수 있습니다:
+
+  git worktree remove [worktree 경로]
+  git branch -d [브랜치명]
+
+지금 worktree를 제거하시겠습니까? (keep/remove)
+```
+
+- **keep**: worktree 유지 (PR 리뷰 중 추가 수정 가능)
+- **remove**: worktree 및 브랜치 즉시 삭제
+
+> worktree가 아닌 일반 브랜치에서 작업 중이면 이 단계를 건너뜀.
+
+## 8. 완료 요약
 
 ```
 ╔══════════════════════════════════════╗
@@ -98,6 +121,7 @@ gh issue edit $ISSUE_NUM \
 이슈: #N [제목]
 PR: [PR URL]
 브랜치: [브랜치명]
+Worktree: [worktree 경로 또는 "N/A"]
 검증: PASS (7/7 단계)
 
 → @claude 멘션 또는 /review 로 코드리뷰를 진행하세요

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start
-description: GitHub 이슈 N번 작업 시작. 브랜치 생성, 이슈 컨텍스트 로드, 아키텍처 규칙 확인.
-argument-hint: "<issue-number>"
+description: GitHub 이슈 N번 작업 시작. 브랜치 생성, worktree 격리, 이슈 컨텍스트 로드, 아키텍처 규칙 확인.
+argument-hint: "<issue-number> [--no-worktree]"
 tools:
   - Bash
   - Read
@@ -13,8 +13,12 @@ Arguments: $ARGUMENTS
 
 ## 1. 입력 검증
 
-이슈 번호가 숫자인지 확인. 아니면:
-"사용법: /start <이슈번호>  예: /start 42"
+인수에서 이슈 번호와 플래그 파싱:
+- 첫 번째 숫자 인수 → 이슈 번호
+- `--no-worktree` → worktree 생성 없이 기존 방식(브랜치만 생성)
+
+이슈 번호가 없으면:
+"사용법: /start <이슈번호> [--no-worktree]  예: /start 42"
 
 ## 2. 현재 Git 상태 확인
 
@@ -37,9 +41,10 @@ gh issue view $ARGUMENTS --json title,body,labels,milestone,assignees
 ## 4. main 브랜치 최신화
 
 ```bash
-git checkout main
-git pull origin main
+git fetch origin main
 ```
+
+> 다른 worktree에서 main이 checkout 되어 있을 수 있으므로 `git checkout main` 대신 `git fetch`만 수행.
 
 ## 5. 브랜치 생성
 
@@ -49,23 +54,63 @@ git pull origin main
 - 형식: `feat/issue-N-title-slug`
 
 ```bash
-git checkout -b feat/issue-N-title-slug
+git branch feat/issue-N-title-slug origin/main
 ```
 
-## 6. 이슈 상태 업데이트
+## 6. Worktree 생성 (기본 동작)
+
+**`--no-worktree` 플래그가 없으면 (기본)**:
+
+### 6a. 기존 worktree 확인
 
 ```bash
-gh issue edit $ARGUMENTS --add-label "in-progress"
+git worktree list | grep "issue-N"
 ```
 
-## 7. 작업 컨텍스트 요약 출력
+이미 해당 이슈의 worktree가 존재하면 재사용:
+"기존 worktree를 발견했습니다: [경로]. 해당 worktree를 사용합니다."
+
+### 6b. 새 worktree 생성
+
+```bash
+git worktree add .claude/worktrees/issue-N-slug feat/issue-N-title-slug
+```
+
+- worktree 경로: `.claude/worktrees/issue-N-slug` (리포지토리 루트 기준)
+- 브랜치는 Step 5에서 생성한 것을 사용
+
+### 6c. 작업 디렉터리 이동 안내
+
+worktree가 생성되면 사용자에게 안내:
+```
+Worktree 생성 완료: .claude/worktrees/issue-N-slug
+이후 작업은 해당 worktree에서 진행하세요.
+```
+
+**`--no-worktree` 플래그가 있으면**:
+
+기존 방식으로 브랜치만 checkout:
+```bash
+git checkout feat/issue-N-title-slug
+```
+
+## 7. 이슈 상태 업데이트
+
+```bash
+gh issue edit $ISSUE_NUM --add-label "in-progress" 2>/dev/null || true
+```
+
+> `in-progress` 라벨이 없으면 무시.
+
+## 8. 작업 컨텍스트 요약 출력
 
 ```
 ╔══════════════════════════════════════╗
 ║    이슈 #N 작업 시작                  ║
-╚══════════════════════════════════════╝
+╚══════════════════════════════════╝
 제목: [이슈 제목]
 브랜치: feat/issue-N-title-slug
+Worktree: .claude/worktrees/issue-N-slug
 라벨: [라벨들]
 
 📋 Acceptance Criteria:
@@ -81,7 +126,9 @@ gh issue edit $ARGUMENTS --add-label "in-progress"
 → 다음 단계: 개발 후 /commit, 완료 시 /done
 ```
 
-## 8. 관련 파일 힌트 제공
+> `--no-worktree` 모드이면 `Worktree:` 줄은 생략.
+
+## 9. 관련 파일 힌트 제공
 
 이슈 제목의 키워드로 관련 파일 검색:
 ```bash


### PR DESCRIPTION
## Related Issue
Closes #89

## Type of Change
- [x] New feature

## Summary
`/start` 스킬에 git worktree 자동 생성 기능을 추가하고, `/done` 스킬에 worktree 정리 안내를 추가합니다.

## Changes Made
- `.claude/skills/start/SKILL.md`:
  - `--no-worktree` 플래그 지원 추가
  - Step 4: `git checkout main` → `git fetch origin main` (worktree 충돌 방지)
  - Step 5: `git checkout -b` → `git branch ... origin/main` (checkout 없이 브랜치 생성)
  - Step 6 (신규): worktree 생성 단계 (기존 확인 → 생성 → 안내)
  - Step 7: 라벨 실패 시 무시 (`2>/dev/null || true`)
  - Step 8: 컨텍스트 요약에 `Worktree:` 줄 추가
- `.claude/skills/done/SKILL.md`:
  - Step 7 (신규): worktree 정리 안내 (keep/remove 선택)
  - Step 8: 완료 요약에 `Worktree:` 줄 추가

## Checklist
- [x] Commit messages follow conventional commits
- [x] No hardcoded secrets
- [x] No TODO/FIXME in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)