### PR TITLE
feat(make): make_auto_open 설정으로 에디터 자동 열기 제어

### DIFF
--- a/docs/dev/testing/edge-cases.md
+++ b/docs/dev/testing/edge-cases.md
@@ -73,6 +73,8 @@
 | M19 | UX | 에디터 미설정 + 선오픈 | 에디터 미설정이면 선오픈도 하지 않는다 (open_editor 미호출) | N/A | 아니오 |
 | M20 | 패키징 | PyPI 설치 시 prompts/templates 리소스 접근 | `get_prompt_file()`, `get_languages_json()`, `get_template_lang_dir()` 등이 정상 Path 반환 | N/A | 아니오 |
 | M21 | skeleton | Solution 주석 한글 + 문제 설명 요약 | make-skeleton 프롬프트에 한글 주석 규칙과 문제 설명 요약 주석 포함 지시 | N/A | 아니오 |
+| M22 | config | `make_auto_open=false` → 에디터 미열기 | config 설정으로 에디터 자동 열기 비활성화 | N/A | 아니오 |
+| M22a | config | `--no-open` flag → config 무관 에디터 미열기 | 플래그가 config보다 우선 | N/A | 아니오 |
 
 ---
 

--- a/src/cli/boj_make.py
+++ b/src/cli/boj_make.py
@@ -116,7 +116,8 @@ def _run_pipeline(args: argparse.Namespace) -> int:
     generate_readme(problem_json)
 
     # Step 2: 에디터 선오픈 — README 직후, spec/skeleton 대기 중 문제 확인 가능
-    editor_cmd = config_get("editor", DEFAULTS.get("editor", "")) if not args.no_open else ""
+    auto_open = config_get("make_auto_open", "true").lower() == "true"
+    editor_cmd = config_get("editor", DEFAULTS.get("editor", "")) if (not args.no_open and auto_open) else ""
     if editor_cmd:
         print("[3/6] 에디터 열기...", file=sys.stderr)
         open_editor(problem_dir, editor_cmd)

--- a/tests/unit/test_make.py
+++ b/tests/unit/test_make.py
@@ -827,6 +827,81 @@ class TestRunPipelineCallOrder:
         assert result == 0
         mock_editor.assert_not_called()
 
+    def test_make_auto_open_false_skips_editor(self, problem_fixture):
+        """M20: make_auto_open=false이면 open_editor가 호출되지 않는다."""
+        from src.cli.boj_make import _run_pipeline, parse_args
+
+        def config_auto_open_false(key, default=""):
+            return {
+                "agent": "echo mock",
+                "prog_lang": "java",
+                "solution_root": "",
+                "editor": "code",
+                "make_auto_open": "false",
+            }.get(key, default)
+
+        args = parse_args(["99999"])
+        with (
+            patch("src.cli.boj_make.config_get", side_effect=config_auto_open_false),
+            patch("src.cli.boj_make.fetch_problem", return_value=problem_fixture),
+            patch("src.cli.boj_make.generate_readme"),
+            patch("src.cli.boj_make.open_editor") as mock_editor,
+            patch("src.cli.boj_make.generate_spec"),
+            patch("src.cli.boj_make.generate_skeleton"),
+            patch("src.cli.boj_make.cleanup_artifacts"),
+        ):
+            result = _run_pipeline(args)
+
+        assert result == 0
+        mock_editor.assert_not_called()
+
+    def test_make_auto_open_true_opens_editor(self, problem_fixture):
+        """M21: make_auto_open=true(기본값)이면 에디터가 열린다."""
+        from src.cli.boj_make import _run_pipeline, parse_args
+
+        def config_auto_open_true(key, default=""):
+            return {
+                "agent": "echo mock",
+                "prog_lang": "java",
+                "solution_root": "",
+                "editor": "code",
+                "make_auto_open": "true",
+            }.get(key, default)
+
+        args = parse_args(["99999"])
+        with (
+            patch("src.cli.boj_make.config_get", side_effect=config_auto_open_true),
+            patch("src.cli.boj_make.fetch_problem", return_value=problem_fixture),
+            patch("src.cli.boj_make.generate_readme"),
+            patch("src.cli.boj_make.open_editor") as mock_editor,
+            patch("src.cli.boj_make.generate_spec"),
+            patch("src.cli.boj_make.generate_skeleton"),
+            patch("src.cli.boj_make.cleanup_artifacts"),
+        ):
+            result = _run_pipeline(args)
+
+        assert result == 0
+        mock_editor.assert_called_once()
+
+    def test_no_open_flag_overrides_auto_open_config(self, problem_fixture):
+        """M21a: --no-open 플래그는 make_auto_open=true여도 에디터를 열지 않는다."""
+        from src.cli.boj_make import _run_pipeline, parse_args
+
+        args = parse_args(["99999", "--no-open"])
+        with (
+            patch("src.cli.boj_make.config_get", side_effect=self._config_get),
+            patch("src.cli.boj_make.fetch_problem", return_value=problem_fixture),
+            patch("src.cli.boj_make.generate_readme"),
+            patch("src.cli.boj_make.open_editor") as mock_editor,
+            patch("src.cli.boj_make.generate_spec"),
+            patch("src.cli.boj_make.generate_skeleton"),
+            patch("src.cli.boj_make.cleanup_artifacts"),
+        ):
+            result = _run_pipeline(args)
+
+        assert result == 0
+        mock_editor.assert_not_called()
+
 
 # ──────────────────────────────────────────────
 # TestOpenEditor


### PR DESCRIPTION
## Summary
- `make_auto_open` config 키 추가 (기본값: `true`)
- `false`로 설정하면 `--no-open` 없이도 에디터를 열지 않음
- 우선순위: `--no-open` flag > `make_auto_open` config > default(true)

## Test plan
- [x] `make_auto_open=false` → 에디터 미열기
- [x] `make_auto_open=true` → 에디터 열기
- [x] `--no-open` flag → config 무관하게 에디터 미열기
- [x] 전체 단위 테스트 통과

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)