### PR TITLE
feat(submit): 제출 페이지 자동 열기 기본값 + config 지원

### DIFF
--- a/src/cli/boj_submit.py
+++ b/src/cli/boj_submit.py
@@ -43,7 +43,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--open",
         action="store_true",
         dest="open_browser",
-        help="제출 페이지 브라우저 열기",
+        default=None,
+        help="제출 페이지 브라우저 열기 (기본값: config 참조)",
+    )
+    parser.add_argument(
+        "--no-open",
+        action="store_true",
+        dest="no_open_browser",
+        help="제출 페이지 브라우저 열지 않기",
     )
     parser.add_argument(
         "--force", "-f",
@@ -137,8 +144,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{BLUE}생성된 파일: {submit_path}{NC}")
         print()
 
-        # --open: 제출 페이지 브라우저 오픈
-        if args.open_browser:
+        # 브라우저 오픈: --no-open > --open > config > default(true)
+        should_open = not args.no_open_browser and (
+            args.open_browser or config_get("submit_open", "true").lower() == "true"
+        )
+        if should_open:
             url = f"https://www.acmicpc.net/submit/{args.problem_id}"
             print(f"{BLUE}제출 페이지 오픈: {url}{NC}")
             open_submit_page(args.problem_id)

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -666,3 +666,65 @@ class TestCompileCheck:
         template_dir.mkdir(parents=True)
 
         assert compile_check(submit, template_dir) is False
+
+
+# ---------------------------------------------------------------------------
+# submit_open config — Issue #86
+# ---------------------------------------------------------------------------
+
+class TestSubmitOpenConfig:
+    """Issue #86: submit_open config로 브라우저 자동 열기 제어."""
+
+    def test_default_opens_browser(self):
+        """기본값(config=true)이면 브라우저가 열린다."""
+        from src.cli.boj_submit import parse_args
+        args = parse_args(["99999"])
+        # open_browser=None (기본), no_open_browser=False
+        # config default "true" → should open
+        assert args.open_browser is None
+        assert args.no_open_browser is False
+
+    def test_no_open_flag(self):
+        """--no-open이면 브라우저를 열지 않는다."""
+        from src.cli.boj_submit import parse_args
+        args = parse_args(["99999", "--no-open"])
+        assert args.no_open_browser is True
+
+    def test_open_flag(self):
+        """--open이면 브라우저를 연다."""
+        from src.cli.boj_submit import parse_args
+        args = parse_args(["99999", "--open"])
+        assert args.open_browser is True
+
+    def test_should_open_logic_default_true(self):
+        """config submit_open=true(기본) → 브라우저 열림."""
+        # --no-open=False, --open=None, config="true" → True
+        no_open = False
+        open_flag = None
+        config_val = "true"
+        should_open = not no_open and (open_flag or config_val.lower() == "true")
+        assert should_open is True
+
+    def test_should_open_logic_config_false(self):
+        """config submit_open=false → 브라우저 안 열림."""
+        no_open = False
+        open_flag = None
+        config_val = "false"
+        should_open = not no_open and (open_flag or config_val.lower() == "true")
+        assert should_open is False
+
+    def test_should_open_logic_no_open_overrides(self):
+        """--no-open → config=true여도 안 열림."""
+        no_open = True
+        open_flag = None
+        config_val = "true"
+        should_open = not no_open and (open_flag or config_val.lower() == "true")
+        assert should_open is False
+
+    def test_should_open_logic_open_overrides_config_false(self):
+        """--open → config=false여도 열림."""
+        no_open = False
+        open_flag = True
+        config_val = "false"
+        should_open = not no_open and (open_flag or config_val.lower() == "true")
+        assert should_open is True


### PR DESCRIPTION
## Summary
- `boj submit` 기본 동작을 브라우저 자동 열기로 변경
- `submit_open` config 키 추가 (기본값: `true`)
- `--no-open` 플래그 추가
- 우선순위: `--no-open` > `--open` > config > default(true)

## Test plan
- [x] 기본값(config=true) → 브라우저 열림
- [x] config=false → 브라우저 안 열림
- [x] --no-open → config 무관 안 열림
- [x] --open → config=false여도 열림
- [x] 전체 단위 테스트 통과

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)