### PR TITLE
feat(reset): boj reset 명령어 추가

### DIFF
--- a/src/cli/boj_reset.py
+++ b/src/cli/boj_reset.py
@@ -1,0 +1,66 @@
+"""boj reset CLI 래퍼.
+
+Issue #87 — Solution 파일을 초기 스켈레톤 상태로 되돌린다.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.core.config import config_get
+from src.core.exceptions import BojError
+from src.core.reset import reset_problem
+from src.core.run import find_problem_dir
+
+GREEN = "\033[32m"
+BLUE = "\033[34m"
+NC = "\033[0m"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="boj reset",
+        description="Solution 파일을 초기 스켈레톤 상태로 되돌린다.",
+    )
+    parser.add_argument("problem_id", help="BOJ 문제 번호")
+    parser.add_argument("--force", "-f", action="store_true", help="확인 없이 즉시 초기화")
+    parser.add_argument("--no-backup", action="store_true", help="백업 없이 초기화")
+    parser.add_argument("--lang", default=None, help="언어 override")
+    parser.add_argument("--root", default=None, help="풀이 루트 디렉터리 override")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    lang = args.lang or config_get("prog_lang", "java")
+    root_str = args.root or config_get("solution_root", "")
+    solution_root = Path(root_str) if root_str else Path.cwd()
+
+    problem_dir_str = find_problem_dir(str(solution_root), args.problem_id)
+    if problem_dir_str is None:
+        print(f"Error: '{args.problem_id}'로 시작하는 폴더를 찾을 수 없습니다.", file=sys.stderr)
+        return 1
+
+    problem_dir = Path(problem_dir_str)
+
+    # 확인 프롬프트
+    if not args.force:
+        answer = input(f"정말 {problem_dir.name}의 Solution을 초기화하시겠습니까? (y/N): ")
+        if answer.lower() not in ("y", "yes"):
+            print("취소되었습니다.")
+            return 0
+
+    try:
+        result = reset_problem(problem_dir, lang, force=args.force, no_backup=args.no_backup)
+    except BojError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"{GREEN}Solution 초기화 완료: {problem_dir.name}{NC}")
+    if result["backup_path"]:
+        print(f"  백업: {result['backup_path']}")
+    if result["submit_cleaned"]:
+        print(f"  submit/ 디렉터리 삭제됨")
+
+    return 0

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -22,6 +22,7 @@ COMMANDS = {
     "review": "src.cli.boj_review",
     "submit": "src.cli.boj_submit",
     "setup": "src.cli.boj_setup",
+    "reset": "src.cli.boj_reset",
 }
 
 

--- a/src/core/reset.py
+++ b/src/core/reset.py
@@ -1,0 +1,108 @@
+"""Solution 파일 초기화 모듈.
+
+Issue #87 — boj reset 명령어.
+Solution 파일을 git의 초기 커밋 상태로 되돌린다.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from src.core.exceptions import BojError
+
+
+def find_solution_file(problem_dir: Path, lang: str) -> Path | None:
+    """문제 디렉터리에서 Solution 파일을 찾는다."""
+    candidates = {
+        "java": "Solution.java",
+        "python": "solution.py",
+        "cpp": "Solution.cpp",
+        "c": "Solution.c",
+        "kotlin": "Solution.kt",
+    }
+    filename = candidates.get(lang, f"Solution.{lang}")
+    path = problem_dir / filename
+    return path if path.exists() else None
+
+
+def backup_solution(solution_path: Path) -> Path:
+    """Solution 파일을 .bak으로 백업한다.
+
+    Returns:
+        백업 파일 경로.
+    """
+    bak_path = solution_path.with_suffix(solution_path.suffix + ".bak")
+    shutil.copy2(solution_path, bak_path)
+    return bak_path
+
+
+def restore_solution(problem_dir: Path, solution_path: Path) -> None:
+    """git checkout으로 Solution 파일을 초기 상태로 복원한다.
+
+    Raises:
+        BojError: git이 없거나 복원 실패 시.
+    """
+    rel_path = solution_path.relative_to(problem_dir.parent)
+    result = subprocess.run(
+        ["git", "checkout", "HEAD", "--", str(rel_path)],
+        cwd=str(problem_dir.parent),
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise BojError(
+            f"Solution 복원 실패: {result.stderr.strip() or 'git checkout 에러'}"
+        )
+
+
+def cleanup_submit(problem_dir: Path) -> bool:
+    """submit/ 디렉터리를 삭제한다.
+
+    Returns:
+        삭제했으면 True, 없었으면 False.
+    """
+    submit_dir = problem_dir / "submit"
+    if submit_dir.is_dir():
+        shutil.rmtree(submit_dir)
+        return True
+    return False
+
+
+def reset_problem(
+    problem_dir: Path,
+    lang: str,
+    force: bool = False,
+    no_backup: bool = False,
+) -> dict:
+    """Solution 파일을 초기 상태로 되돌린다.
+
+    Args:
+        problem_dir: 문제 폴더 경로.
+        lang: 프로그래밍 언어.
+        force: True면 확인 없이 진행.
+        no_backup: True면 백업 생성 안 함.
+
+    Returns:
+        결과 딕셔너리 (backup_path, submit_cleaned 등).
+
+    Raises:
+        BojError: Solution 파일이 없을 때.
+    """
+    solution_path = find_solution_file(problem_dir, lang)
+    if solution_path is None:
+        raise BojError(
+            f"Solution 파일을 찾을 수 없습니다: {problem_dir}"
+        )
+
+    result = {"backup_path": None, "submit_cleaned": False}
+
+    # 백업
+    if not no_backup:
+        result["backup_path"] = backup_solution(solution_path)
+
+    # 복원
+    restore_solution(problem_dir, solution_path)
+
+    # submit/ 정리
+    result["submit_cleaned"] = cleanup_submit(problem_dir)
+
+    return result

--- a/tests/unit/test_reset.py
+++ b/tests/unit/test_reset.py
@@ -1,0 +1,135 @@
+"""src/core/reset.py 단위 테스트.
+
+Issue #87 — boj reset 명령어.
+"""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import subprocess
+
+import pytest
+
+from src.core.exceptions import BojError
+from src.core.reset import (
+    find_solution_file,
+    backup_solution,
+    restore_solution,
+    cleanup_submit,
+    reset_problem,
+)
+
+
+class TestFindSolutionFile:
+    """Solution 파일 탐색."""
+
+    def test_finds_java_solution(self, tmp_path):
+        (tmp_path / "Solution.java").write_text("class Solution {}")
+        assert find_solution_file(tmp_path, "java") is not None
+
+    def test_finds_python_solution(self, tmp_path):
+        (tmp_path / "solution.py").write_text("class Solution: pass")
+        assert find_solution_file(tmp_path, "python") is not None
+
+    def test_returns_none_when_missing(self, tmp_path):
+        assert find_solution_file(tmp_path, "java") is None
+
+
+class TestBackupSolution:
+    """Solution 백업."""
+
+    def test_creates_bak_file(self, tmp_path):
+        sol = tmp_path / "Solution.java"
+        sol.write_text("original code")
+        bak = backup_solution(sol)
+        assert bak.exists()
+        assert bak.name == "Solution.java.bak"
+        assert bak.read_text() == "original code"
+
+    def test_preserves_original(self, tmp_path):
+        sol = tmp_path / "Solution.java"
+        sol.write_text("original code")
+        backup_solution(sol)
+        assert sol.read_text() == "original code"
+
+
+class TestRestoreSolution:
+    """git checkout 기반 복원."""
+
+    def test_calls_git_checkout(self, tmp_path):
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+        sol = problem_dir / "Solution.java"
+        sol.write_text("modified")
+
+        with patch("src.core.reset.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            restore_solution(problem_dir, sol)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "git" in cmd
+        assert "checkout" in cmd
+
+    def test_raises_on_git_failure(self, tmp_path):
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+        sol = problem_dir / "Solution.java"
+        sol.write_text("modified")
+
+        with patch("src.core.reset.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="error")
+            with pytest.raises(BojError, match="복원 실패"):
+                restore_solution(problem_dir, sol)
+
+
+class TestCleanupSubmit:
+    """submit/ 디렉터리 삭제."""
+
+    def test_removes_submit_dir(self, tmp_path):
+        submit = tmp_path / "submit"
+        submit.mkdir()
+        (submit / "Submit.java").write_text("code")
+        assert cleanup_submit(tmp_path) is True
+        assert not submit.exists()
+
+    def test_returns_false_when_no_submit(self, tmp_path):
+        assert cleanup_submit(tmp_path) is False
+
+
+class TestResetProblem:
+    """reset_problem 통합 로직."""
+
+    def test_full_reset_with_backup(self, tmp_path):
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+        sol = problem_dir / "Solution.java"
+        sol.write_text("modified code")
+        submit = problem_dir / "submit"
+        submit.mkdir()
+        (submit / "Submit.java").write_text("submit")
+
+        with patch("src.core.reset.restore_solution"):
+            result = reset_problem(problem_dir, "java", force=True)
+
+        assert result["backup_path"] is not None
+        assert result["backup_path"].exists()
+        assert result["submit_cleaned"] is True
+
+    def test_no_backup_flag(self, tmp_path):
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+        sol = problem_dir / "Solution.java"
+        sol.write_text("code")
+
+        with patch("src.core.reset.restore_solution"):
+            result = reset_problem(problem_dir, "java", force=True, no_backup=True)
+
+        assert result["backup_path"] is None
+
+    def test_raises_when_no_solution(self, tmp_path):
+        problem_dir = tmp_path / "99999-test"
+        problem_dir.mkdir()
+
+        with pytest.raises(BojError, match="찾을 수 없습니다"):
+            reset_problem(problem_dir, "java", force=True)


### PR DESCRIPTION
## Summary
- `boj reset <문제번호>` — Solution 파일을 초기 스켈레톤으로 복원
- 확인 프롬프트 (--force로 스킵)
- 백업 .bak 파일 자동 생성 (--no-backup으로 스킵)
- submit/ 디렉터리 자동 삭제

## Test plan
- [x] Solution 파일 탐색 (java, python, 미존재)
- [x] 백업 .bak 파일 생성 + 원본 보존
- [x] git checkout 호출 + 실패 시 에러
- [x] submit/ 디렉터리 삭제
- [x] 통합: 백업 + 복원 + 정리
- [x] --no-backup 플래그
- [x] Solution 없을 때 에러
- [x] 전체 단위 테스트 통과 (12개)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)