### PR TITLE
feat(add-test): boj add-test AI 기반 테스트 케이스 자동 생성

### DIFF
--- a/src/cli/boj_add_test.py
+++ b/src/cli/boj_add_test.py
@@ -1,0 +1,98 @@
+"""boj add-test CLI 래퍼.
+
+Issue #88 — AI 기반 테스트 케이스 자동 생성.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from src.core.config import config_get
+from src.core.exceptions import BojError
+from src.core.add_test import (
+    load_existing_test_cases,
+    merge_test_cases,
+    save_test_cases,
+    parse_agent_response,
+    build_add_test_prompt,
+)
+from src.core.run import find_problem_dir
+
+GREEN = "\033[32m"
+BLUE = "\033[34m"
+NC = "\033[0m"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="boj add-test",
+        description="AI 기반 테스트 케이스 자동 생성",
+    )
+    parser.add_argument("problem_id", help="BOJ 문제 번호")
+    parser.add_argument("--edge", action="store_true", help="엣지 케이스 생성")
+    parser.add_argument("--extreme", action="store_true", help="극한 케이스 생성")
+    parser.add_argument("--count", type=int, default=3, help="생성 개수 (기본 3)")
+    parser.add_argument("--root", default=None, help="풀이 루트 디렉터리 override")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    mode = "extreme" if args.extreme else ("edge" if args.edge else "basic")
+
+    root_str = args.root or config_get("solution_root", "")
+    solution_root = Path(root_str) if root_str else Path.cwd()
+
+    agent_cmd = config_get("agent", "")
+    if not agent_cmd:
+        print("Error: 에이전트가 설정되지 않았습니다. boj setup을 실행하세요.", file=sys.stderr)
+        return 1
+
+    problem_dir_str = find_problem_dir(str(solution_root), args.problem_id)
+    if problem_dir_str is None:
+        print(f"Error: '{args.problem_id}'로 시작하는 폴더를 찾을 수 없습니다.", file=sys.stderr)
+        return 1
+
+    problem_dir = Path(problem_dir_str)
+
+    print(f"{BLUE}[1/3] 기존 테스트 케이스 로드...{NC}", file=sys.stderr)
+    existing = load_existing_test_cases(problem_dir)
+    print(f"  기존 {len(existing)}개 케이스", file=sys.stderr)
+
+    print(f"{BLUE}[2/3] {mode} 모드 테스트 케이스 {args.count}개 생성 중...{NC}", file=sys.stderr)
+    prompt = build_add_test_prompt(problem_dir, mode, args.count, existing)
+
+    import shlex
+    cmd = shlex.split(agent_cmd)
+    try:
+        result = subprocess.run(
+            cmd, input=prompt, capture_output=True, text=True,
+            cwd=str(problem_dir),
+        )
+    except FileNotFoundError:
+        print(f"Error: 에이전트 명령어를 찾을 수 없습니다: {agent_cmd}", file=sys.stderr)
+        return 1
+
+    try:
+        new_cases = parse_agent_response(result.stdout)
+    except BojError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        if result.stderr:
+            print(f"  stderr: {result.stderr[:200]}", file=sys.stderr)
+        return 1
+
+    print(f"{BLUE}[3/3] 테스트 케이스 병합...{NC}", file=sys.stderr)
+    merged, added = merge_test_cases(existing, new_cases, mode=mode)
+
+    if added == 0:
+        print("Warning: 모든 케이스가 중복입니다. 추가된 케이스 없음.", file=sys.stderr)
+        return 0
+
+    tc_path = save_test_cases(problem_dir, merged)
+
+    print(f"{GREEN}완료! {added}개 테스트 케이스 추가 (총 {len(merged)}개){NC}")
+    print(f"  저장: {tc_path}")
+
+    return 0

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -23,6 +23,7 @@ COMMANDS = {
     "submit": "src.cli.boj_submit",
     "setup": "src.cli.boj_setup",
     "reset": "src.cli.boj_reset",
+    "add-test": "src.cli.boj_add_test",
 }
 
 

--- a/src/core/add_test.py
+++ b/src/core/add_test.py
@@ -1,0 +1,226 @@
+"""AI 기반 테스트 케이스 자동 생성 모듈.
+
+Issue #88 — boj add-test 명령어.
+problem.json과 Solution을 분석하여 추가 테스트 케이스를 생성한다.
+"""
+
+import json
+from pathlib import Path
+
+from src.core.exceptions import BojError
+
+
+def load_existing_test_cases(problem_dir: Path) -> list[dict]:
+    """기존 test_cases.json을 읽는다.
+
+    Returns:
+        테스트 케이스 리스트. 파일이 없으면 빈 리스트.
+    """
+    tc_path = problem_dir / "test" / "test_cases.json"
+    if not tc_path.exists():
+        return []
+    data = json.loads(tc_path.read_text(encoding="utf-8"))
+    return data.get("testCases", [])
+
+
+def next_test_id(existing: list[dict]) -> int:
+    """기존 테스트 케이스의 마지막 id + 1을 반환한다."""
+    if not existing:
+        return 1
+    max_id = max(tc.get("id", 0) for tc in existing)
+    return max_id + 1
+
+
+def is_duplicate(new_case: dict, existing: list[dict]) -> bool:
+    """새 테스트 케이스가 기존 케이스와 중복되는지 확인한다.
+
+    input이 동일하면 중복으로 간주.
+    """
+    new_input = new_case.get("input", "").strip()
+    for tc in existing:
+        if tc.get("input", "").strip() == new_input:
+            return True
+    return False
+
+
+def merge_test_cases(
+    existing: list[dict],
+    new_cases: list[dict],
+    mode: str = "basic",
+) -> tuple[list[dict], int]:
+    """새 테스트 케이스를 기존 목록에 병합한다.
+
+    Args:
+        existing: 기존 테스트 케이스 리스트.
+        new_cases: 새로 생성된 테스트 케이스 리스트.
+        mode: 생성 모드 (basic/edge/extreme).
+
+    Returns:
+        (병합된 리스트, 추가된 개수) 튜플.
+    """
+    start_id = next_test_id(existing)
+    added = 0
+    merged = list(existing)
+
+    for case in new_cases:
+        if is_duplicate(case, merged):
+            continue
+
+        merged.append({
+            "id": start_id + added,
+            "input": case.get("input", ""),
+            "expected": case.get("expected", ""),
+            "description": case.get("description", f"{mode} 자동 생성"),
+        })
+        added += 1
+
+    return merged, added
+
+
+def save_test_cases(problem_dir: Path, test_cases: list[dict]) -> Path:
+    """test_cases.json을 저장한다.
+
+    Returns:
+        저장된 파일 경로.
+    """
+    tc_dir = problem_dir / "test"
+    tc_dir.mkdir(exist_ok=True)
+    tc_path = tc_dir / "test_cases.json"
+    data = {"testCases": test_cases}
+    tc_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return tc_path
+
+
+def parse_agent_response(stdout: str) -> list[dict]:
+    """에이전트 stdout에서 새 테스트 케이스를 추출한다.
+
+    에이전트는 {"newTestCases": [...]} 형태의 JSON을 출력한다.
+
+    Returns:
+        새 테스트 케이스 리스트.
+
+    Raises:
+        BojError: JSON 파싱 실패 시.
+    """
+    text = stdout.strip()
+    if not text:
+        raise BojError("에이전트 출력이 비어있습니다.")
+
+    # JSON 블록 추출 (```json ... ``` 또는 순수 JSON)
+    if "```json" in text:
+        start = text.index("```json") + len("```json")
+        end = text.index("```", start)
+        text = text[start:end].strip()
+    elif "```" in text:
+        start = text.index("```") + len("```")
+        end = text.index("```", start)
+        text = text[start:end].strip()
+
+    # 첫 번째 { 부터 마지막 } 까지 추출
+    first_brace = text.find("{")
+    last_brace = text.rfind("}")
+    if first_brace == -1 or last_brace == -1:
+        raise BojError("에이전트 출력에서 JSON을 찾을 수 없습니다.")
+
+    json_str = text[first_brace:last_brace + 1]
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        raise BojError(f"에이전트 출력 JSON 파싱 실패: {e}")
+
+    cases = data.get("newTestCases", [])
+    if not cases:
+        raise BojError("에이전트가 테스트 케이스를 생성하지 않았습니다.")
+
+    return cases
+
+
+def build_add_test_prompt(
+    problem_dir: Path,
+    mode: str,
+    count: int,
+    existing: list[dict],
+) -> str:
+    """add-test 프롬프트를 구성한다.
+
+    Args:
+        problem_dir: 문제 폴더 경로.
+        mode: 생성 모드 (basic/edge/extreme).
+        count: 생성할 테스트 케이스 수.
+        existing: 기존 테스트 케이스.
+
+    Returns:
+        완성된 프롬프트 문자열.
+    """
+    # problem.json 읽기
+    problem_json = problem_dir / "artifacts" / "problem.json"
+    if not problem_json.exists():
+        # artifacts 없으면 상위에서 찾기
+        problem_json = problem_dir / "problem.json"
+    problem_data = ""
+    if problem_json.exists():
+        problem_data = problem_json.read_text(encoding="utf-8")
+
+    # Solution 파일 읽기
+    solution_content = ""
+    for name in ("Solution.java", "solution.py", "Solution.cpp", "Solution.c"):
+        sol = problem_dir / name
+        if sol.exists():
+            solution_content = sol.read_text(encoding="utf-8")
+            break
+
+    mode_desc = {
+        "basic": "기본적인 테스트 케이스 (해피패스, 간단한 변형)",
+        "edge": "경계값, 빈 입력, 최소/최대값, 특수 케이스",
+        "extreme": "최악의 시나리오 — 최대 입력 크기, TLE/MLE 유발 가능한 극단적 케이스",
+    }
+
+    existing_json = json.dumps(existing, ensure_ascii=False, indent=2) if existing else "[]"
+
+    prompt = f"""# 테스트 케이스 자동 생성
+
+## 모드: {mode} — {mode_desc.get(mode, mode)}
+## 생성 개수: {count}개
+
+## 문제 정보
+```json
+{problem_data}
+```
+
+## 현재 Solution
+```
+{solution_content}
+```
+
+## 기존 테스트 케이스 (중복 금지)
+```json
+{existing_json}
+```
+
+## 추론 단계 (Chain-of-Thought)
+
+1. **문제 분석**: 입력 형식, 제약 조건, 알고리즘 유형을 파악하세요.
+2. **기존 테스트 분석**: 이미 커버된 시나리오를 확인하세요.
+3. **누락 시나리오 도출**: {mode} 모드에 맞는 테스트 케이스 후보를 추론하세요.
+4. **케이스 생성**: input/expected 쌍을 {count}개 생성하세요.
+5. **검증**: 기존 케이스와 중복이 없는지 확인하세요.
+
+## 출력 형식 (반드시 이 JSON 형식으로만 출력)
+
+```json
+{{
+  "newTestCases": [
+    {{"input": "...", "expected": "..."}},
+    ...
+  ],
+  "reasoning": "생성 근거 설명..."
+}}
+```
+
+중요: JSON 외의 텍스트를 출력하지 마세요.
+"""
+    return prompt

--- a/tests/unit/test_add_test.py
+++ b/tests/unit/test_add_test.py
@@ -1,0 +1,177 @@
+"""src/core/add_test.py 단위 테스트.
+
+Issue #88 — boj add-test 명령어.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.core.exceptions import BojError
+from src.core.add_test import (
+    load_existing_test_cases,
+    next_test_id,
+    is_duplicate,
+    merge_test_cases,
+    save_test_cases,
+    parse_agent_response,
+    build_add_test_prompt,
+)
+
+
+class TestLoadExistingTestCases:
+    """기존 test_cases.json 로드."""
+
+    def test_loads_existing(self, tmp_path):
+        tc_dir = tmp_path / "test"
+        tc_dir.mkdir()
+        (tc_dir / "test_cases.json").write_text(json.dumps({
+            "testCases": [{"id": 1, "input": "1 2", "expected": "3"}]
+        }))
+        result = load_existing_test_cases(tmp_path)
+        assert len(result) == 1
+        assert result[0]["input"] == "1 2"
+
+    def test_returns_empty_when_missing(self, tmp_path):
+        assert load_existing_test_cases(tmp_path) == []
+
+
+class TestNextTestId:
+    """다음 테스트 ID 계산."""
+
+    def test_returns_1_for_empty(self):
+        assert next_test_id([]) == 1
+
+    def test_returns_next_id(self):
+        existing = [{"id": 1}, {"id": 3}, {"id": 2}]
+        assert next_test_id(existing) == 4
+
+    def test_handles_missing_id(self):
+        existing = [{"input": "1"}, {"id": 5}]
+        assert next_test_id(existing) == 6
+
+
+class TestIsDuplicate:
+    """중복 감지."""
+
+    def test_detects_exact_duplicate(self):
+        existing = [{"input": "1 2", "expected": "3"}]
+        assert is_duplicate({"input": "1 2"}, existing) is True
+
+    def test_detects_whitespace_duplicate(self):
+        existing = [{"input": "1 2 ", "expected": "3"}]
+        assert is_duplicate({"input": " 1 2"}, existing) is True
+
+    def test_no_duplicate(self):
+        existing = [{"input": "1 2", "expected": "3"}]
+        assert is_duplicate({"input": "3 4"}, existing) is False
+
+    def test_empty_existing(self):
+        assert is_duplicate({"input": "1 2"}, []) is False
+
+
+class TestMergeTestCases:
+    """테스트 케이스 병합."""
+
+    def test_merges_new_cases(self):
+        existing = [{"id": 1, "input": "1 2", "expected": "3"}]
+        new = [{"input": "3 4", "expected": "7"}]
+        merged, added = merge_test_cases(existing, new)
+        assert added == 1
+        assert len(merged) == 2
+        assert merged[1]["id"] == 2
+        assert merged[1]["input"] == "3 4"
+
+    def test_skips_duplicates(self):
+        existing = [{"id": 1, "input": "1 2", "expected": "3"}]
+        new = [{"input": "1 2", "expected": "3"}]
+        merged, added = merge_test_cases(existing, new)
+        assert added == 0
+        assert len(merged) == 1
+
+    def test_adds_description_with_mode(self):
+        merged, _ = merge_test_cases([], [{"input": "1", "expected": "1"}], mode="edge")
+        assert "edge" in merged[0]["description"]
+
+    def test_preserves_custom_description(self):
+        new = [{"input": "1", "expected": "1", "description": "커스텀"}]
+        merged, _ = merge_test_cases([], new)
+        assert merged[0]["description"] == "커스텀"
+
+
+class TestSaveTestCases:
+    """test_cases.json 저장."""
+
+    def test_creates_file(self, tmp_path):
+        cases = [{"id": 1, "input": "1 2", "expected": "3"}]
+        path = save_test_cases(tmp_path, cases)
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert len(data["testCases"]) == 1
+
+    def test_creates_test_dir(self, tmp_path):
+        save_test_cases(tmp_path, [])
+        assert (tmp_path / "test").is_dir()
+
+
+class TestParseAgentResponse:
+    """에이전트 응답 파싱."""
+
+    def test_parses_pure_json(self):
+        stdout = json.dumps({
+            "newTestCases": [{"input": "1", "expected": "1"}],
+            "reasoning": "test",
+        })
+        result = parse_agent_response(stdout)
+        assert len(result) == 1
+
+    def test_parses_json_in_code_fence(self):
+        stdout = 'Here:\n```json\n{"newTestCases": [{"input": "1", "expected": "1"}]}\n```'
+        result = parse_agent_response(stdout)
+        assert len(result) == 1
+
+    def test_raises_on_empty(self):
+        with pytest.raises(BojError, match="비어있습니다"):
+            parse_agent_response("")
+
+    def test_raises_on_no_json(self):
+        with pytest.raises(BojError, match="JSON을 찾을 수 없습니다"):
+            parse_agent_response("no json here")
+
+    def test_raises_on_invalid_json(self):
+        with pytest.raises(BojError, match="파싱 실패"):
+            parse_agent_response("{invalid json}")
+
+    def test_raises_on_empty_test_cases(self):
+        with pytest.raises(BojError, match="생성하지 않았습니다"):
+            parse_agent_response('{"newTestCases": []}')
+
+
+class TestBuildAddTestPrompt:
+    """프롬프트 구성."""
+
+    def test_includes_mode(self, tmp_path):
+        prompt = build_add_test_prompt(tmp_path, "edge", 3, [])
+        assert "edge" in prompt
+
+    def test_includes_count(self, tmp_path):
+        prompt = build_add_test_prompt(tmp_path, "basic", 5, [])
+        assert "5" in prompt
+
+    def test_includes_existing_cases(self, tmp_path):
+        existing = [{"id": 1, "input": "1 2", "expected": "3"}]
+        prompt = build_add_test_prompt(tmp_path, "basic", 3, existing)
+        assert "1 2" in prompt
+
+    def test_includes_problem_json(self, tmp_path):
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "problem.json").write_text('{"title": "테스트 문제"}')
+        prompt = build_add_test_prompt(tmp_path, "basic", 3, [])
+        assert "테스트 문제" in prompt
+
+    def test_includes_solution(self, tmp_path):
+        (tmp_path / "Solution.java").write_text("public class Solution {}")
+        prompt = build_add_test_prompt(tmp_path, "basic", 3, [])
+        assert "public class Solution" in prompt


### PR DESCRIPTION
## Summary
- `boj add-test <문제번호>` — AI로 테스트 케이스 자동 생성
- 3가지 모드: basic(기본), --edge(경계값), --extreme(극한)
- 기존 test_cases.json에 append (중복 자동 스킵)
- Chain-of-Thought 프롬프트 설계

## Test plan
- [x] 기존 test_cases.json 로드 / 없으면 빈 리스트
- [x] 다음 테스트 ID 계산
- [x] 중복 감지 (input 기준, 공백 정규화)
- [x] 병합: 새 케이스 추가 + 중복 스킵
- [x] 저장: test/ 디렉터리 생성 + JSON 저장
- [x] 에이전트 응답 파싱 (순수 JSON, code fence, 에러 케이스)
- [x] 프롬프트 구성 (모드, 개수, problem.json, Solution 포함)
- [x] 전체 단위 테스트 통과 (26개)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)